### PR TITLE
Add browser-detected darkmode support

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -48,15 +48,22 @@ $pad_: 20px; // tablet and mobile
 
 // Colors, Fonts, Frills =======================================================
 
-$text: #222;
-$text_subtle: #999;
-$subtle: #ddd;
-$subtle_: #aaa;
+:root {
+  --text: #222;
+  --text_subtle: #999;
+  --subtle: #ddd;
+  --subtle_: #aaa;
+  --link: blue;
+  --bg: #fff;
+  --bg_: #f5f5f5;
+}
+
 
 // Fonts
 body {
+  background-color:var(--bg);
 	font-family:'Source Code Pro', 'Helvetica', 'Arial', sans-serif; font-size:16px;
-	line-height:1.6; font-weight:400; color:$text;
+	line-height:1.6; font-weight:400; color:var(--text);
 }
 em {font-weight:400; font-style:italic;}
 b {font-weight:700;}
@@ -69,14 +76,14 @@ h2 {
 	@include breakpoint(s) {font-size:22px;}
 }
 a {
-	border-bottom:1px solid $subtle;
+	border-bottom:1px solid var(--subtle);
 	&:hover {
-		border-bottom:1px solid $subtle_;
+		border-bottom:1px solid var(--subtle_);
 	}
 }
 p.divider {
 	&:before {
-		content:""; display:block; width:48px; border-bottom:1px solid $subtle; margin-bottom:20px;
+		content:""; display:block; width:48px; border-bottom:1px solid var(--subtle); margin-bottom:20px;
 	}
 	line-height:1.6;
 	max-width:580px;
@@ -94,16 +101,16 @@ header {
 #emailLinks {
 	.state {margin-top:8px;}
 	h2 {margin-bottom:8px;}
-	a {color:blue;}
-	a:visited {color:$text;}
+	a {color:var(--link);}
+	a:visited {color:var(--text);}
 }
 .emailPageHeader {
 	.buttons {
 		margin-top:20px;
-		a {display:inline-block; margin-right:12px; color:blue; cursor:pointer;}
+		a {display:inline-block; margin-right:12px; color:var(--link); cursor:pointer;}
 	}
 }
-.emailContentSection {background:#f5f5f5;}
+.emailContentSection {background:var(--bg_);}
 .emailContent {
 	div {margin-top:20px;}
 	.recipients {overflow-wrap: break-word;}

--- a/css/main.scss
+++ b/css/main.scss
@@ -56,8 +56,17 @@ $pad_: 20px; // tablet and mobile
   --link: blue;
   --bg: #fff;
   --bg_: #f5f5f5;
+  
+  @media (prefers-color-scheme: dark) {
+    --text: #ddd;
+    --text_subtle: #666;
+    --subtle: #252525;
+    --subtle_: #555;
+    --link: #3C81F9;
+    --bg: #111;
+    --bg_: #181818;
+  }
 }
-
 
 // Fonts
 body {


### PR DESCRIPTION
<img width="284" alt="Screen Shot 2020-06-06 at 8 58 41 PM" src="https://user-images.githubusercontent.com/221550/83957727-3dff5500-a838-11ea-9977-128b3891fa99.png" align="right"> 

This PR:

* Changes SCSS variables to [CSS variables](https://caniuse.com/#feat=css-variables)
* Uses the [`prefers-color-scheme` media query](https://caniuse.com/#search=prefers-color-scheme) to change the value of those variables when the browser detects the device uses dark mode

The blue (`#0000ff`) link color is inaccessible on dark backgrounds, so it was changed to the brightest value/saturation in the similar hue group as #0000ff as I deemed reasonable, `#3d81fa`. This color can be changed to something else if it doesn’t fit the intended site aesthetic.

| Light mode (current, default) | Dark mode |
| --- | --- |
| <img width="762" alt="Screen Shot 2020-06-06 at 9 00 42 PM" src="https://user-images.githubusercontent.com/221550/83957783-95052a00-a838-11ea-97ff-cd9093dea6a6.png"> | <img width="760" alt="Screen Shot 2020-06-06 at 9 00 23 PM" src="https://user-images.githubusercontent.com/221550/83957793-9c2c3800-a838-11ea-9d33-176d1c7600aa.png"> |

---

### Future considerations
When the site framework moves to Gatsby/React, I will add support for a toggle UI component so users can choose which version they prefer. 