### PR TITLE
Define HTML lang

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
 


### PR DESCRIPTION
🌐  Just a tiny lil accessibility win!

> If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [[source](https://web.dev/html-has-lang/?utm_source=lighthouse&utm_medium=devtools)]