### PR TITLE
Added no-response bot and new labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -2,7 +2,7 @@
 title: ''
 name: Report a bug
 about: Found a problem with the site?
-labels: bug
+labels: bug, pending
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/EMAIL_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/EMAIL_REQUEST.md
@@ -2,7 +2,7 @@
 title: ''
 name: Add or edit an email for your city
 about: Update defund12.org with a message for your community.
-labels: new-request
+labels: new-request, pending
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/EMAIL_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/EMAIL_REQUEST.md
@@ -1,5 +1,5 @@
 ---
-title: ''
+title: 'Please add *INSERT CITY HERE*'
 name: Add or edit an email for your city
 about: Update defund12.org with a message for your community.
 labels: new-request, pending

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -2,7 +2,7 @@
 title: ''
 name: Feature request
 about: Want to add a new feature to the site?
-labels: feature
+labels: feature, pending 
 assignees: ''
 ---
 

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,41 @@
+# Configuration for request-info - https://github.com/behaviorbot/request-info
+
+# *OPTIONAL* Comment to reply with
+# Can be either a string :
+requestInfoReplyComment: >
+  We would appreciate it if you could provide us with more info about this issue/pr! Please fill out all information requested in the issue template so we can best handle your request. 
+
+# Or an array:
+# requestInfoReplyComment:
+#  - Ah no! young blade! That was a trifle short!
+#  - Tell me more !
+#  - I am sure you can be more effusive
+
+
+# *OPTIONAL* default titles to check against for lack of descriptiveness
+# MUST BE ALL LOWERCASE
+requestInfoDefaultTitles:
+  - please add *insert city here*
+
+# *OPTIONAL* Label to be added to Issues and Pull Requests with insufficient information given
+requestInfoLabelToAdd: needs-response 
+
+# *OPTIONAL* Require Issues to contain more information thanwhat is provided in the issue templates
+# Will fail if the issue's body is equal to a provided template
+checkIssueTemplate: true
+
+# *OPTIONAL* Require Pull Requests to contain more information than what is provided in the PR template
+# Will fail if the pull request's body is equal to the provided template
+#checkPullRequestTemplate: true
+
+# *OPTIONAL* Only warn about insufficient information on these events type
+# Keys must be lowercase. Valid values are 'issue' and 'pullRequest'
+requestInfoOn:
+  issue: true
+#  pullRequest: true
+
+# *OPTIONAL* Add a list of people whose Issues/PRs will not be commented on
+# keys must be GitHub usernames
+#requestInfoUserstoExclude:
+#  - hiimbex
+#  - bexo 

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -3,7 +3,7 @@
 # Number of days of inactivity before an Issue is closed for lack of response
 daysUntilClose: 3 
 # Label requiring a response
-responseRequiredLabel: email-needs-work
+responseRequiredLabel: needs-response 
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable
 closeComment: >
   This issue has been automatically closed because there has been no response

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 3 
+# Label requiring a response
+responseRequiredLabel: email-needs-work
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.


### PR DESCRIPTION
Hey all,

I need a few things from project maintainers to make this go through:

- Add no response bot to the repo (https://github.com/apps/no-response)
- Add a "pending" and "needs-response" to our labels
- Tell the teams to use the "needs-response" for responses on ALL ISSUES, emails, bug reports, feature requests

