### PR TITLE
Remove bogus escaping of brackets in email bodies

### DIFF
--- a/_emails/us/arizona/phoenix.md
+++ b/_emails/us/arizona/phoenix.md
@@ -18,17 +18,16 @@ subject: Reallocate police funds for social equity
 body: |-
   Dear Phoenix Mayor and Council members,
 
-  My name is \[NAME\] and I live in \[DISTRICT OR CITY\]. I am writing to you as a constituent who is disturbed by the injustices and brutality carried out by police forces across the country, and particularly in the Phoenix PD. In February, the council approved a community review board and Office of Accountability and Transparency. They were given the power to:
+  My name is [NAME] and I live in [DISTRICT OR CITY]. I am writing to you as a constituent who is disturbed by the injustices and brutality carried out by police forces across the country, and particularly in the Phoenix PD. In February, the council approved a community review board and Office of Accountability and Transparency. They were given the power to:
   -investigate and provide independent reports on police use-of-force incidents and citizen complaints
   -make disciplinary recommendations for individual officers to the Police chief
   -recommend policy changes based on research and community feedback
   When the council approved the plan, it anticipated it would cost about $3 million, but in Wednesday’s 2020-21 budget decision it only received $400,000. In 2019, The Phoenix PD received $721 million from the City of Phoenix. The current City Manager recommendation is $741 million, a $20 million increase, yet they can’t provide $3 million to OAT. Ending police brutality should be a budget priority. Justice should be a budget priority. Health and safety--which are proven to be better promoted through social programs and education than policing--should be a priority. I demand that you, as a representative of your Phoenix constituents, fully fund OAT, and redirect a meaningful portion of the Phoenix PD budget to social services, cultural programs, and education, which are backbones of any healthy community. Thank you.
 
   Sincerely,
-  \[NAME\]
-  \[ADDRESS\]
-  \[EMAIL\]
-  \[PHONE NUMBER\]
+  [NAME]
+  [ADDRESS]
+  [EMAIL]
+  [PHONE NUMBER]
 layout: email
 ---
-

--- a/_emails/us/california/eureka.md
+++ b/_emails/us/california/eureka.md
@@ -16,7 +16,7 @@ subject: Commit to reallocate for social equity
 body: |-
   To the Eureka City Council,
 
-  I am a resident of Eureka's \[YOUR WARD/NEIGHBORHOOD\]. I am writing to demand that the City Council adopt a budget strategy that prioritizes community well-being and redirects funding away from the police in the next budget evaluation period.
+  I am a resident of Eureka's [YOUR WARD/NEIGHBORHOOD]. I am writing to demand that the City Council adopt a budget strategy that prioritizes community well-being and redirects funding away from the police in the next budget evaluation period.
 
   We have seen mounting evidence that police departments are ineffective institutions that marginalize minority communities and put citizens at risk of injury and death, yet the police budget accounts for 46% of our general fund. This is wholly unacceptable. I ask that you redirect a significant portion of the police budget toward community programs that provide citizens with basic human needs, like affordable healthcare and housing. We don’t need a militarized police force. We need to create a space in which more mental health service providers, social workers, victim/survivor advocates, religious leaders, neighbors, and friends - all of the people who really make up our community - can look out for one another. Real, actionable change starts with reallocating funding in a manner consistent with these priorities.
 
@@ -24,10 +24,10 @@ body: |-
 
   Thank you for your time,
 
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR PHONE NUMBER\]
-  \[YOUR EMAIL ADDRESS\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR PHONE NUMBER]
+  [YOUR EMAIL ADDRESS]
 layout: email
 ---
 

--- a/_emails/us/california/fremont.md
+++ b/_emails/us/california/fremont.md
@@ -18,7 +18,7 @@ subject: Fremont Resident for Defunding the Fremont PD
 body: |-
   To Mayor Mei, the Fremont City Council, Fremont City Manager, and Fremont Police Chief:
 
-  My name is \[YOUR NAME\], and I am a resident of Fremont. I am writing to demand that the City Council adopts a People’s Budget that prioritizes community wellbeing and redirects funding away from the police.
+  My name is [YOUR NAME], and I am a resident of Fremont. I am writing to demand that the City Council adopts a People’s Budget that prioritizes community wellbeing and redirects funding away from the police.
 
   This past week, our nation has been gripped by protests calling for a rapid and meaningful reconsideration of the role of policing in communities as well as an end to racism and anti-Blackness in America. The Bay Area has been at the forefront of much of this action. Accordingly, it has come to my attention that the budget for 2021 is being decided as these protests continue.
 
@@ -34,10 +34,10 @@ body: |-
 
   Sincerely,
 
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
 

--- a/_emails/us/california/longbeach.md
+++ b/_emails/us/california/longbeach.md
@@ -20,16 +20,16 @@ subject: Defund Long Beach Police
 body: |-
   Dear Long Beach Mayor and City Council,
 
-  My name is \[YOUR NAME\], I am a resident of \[YOUR DISTRICT\]. I am demanding reallocation of funding from LBPD to social and public programming that takes place in our communities. It is an outrage that 48.3% of the city funding for 2021 is planned to be allocated to the Police Department and that Chief Luna’s salary is equivalent to that of the president of the United States.
+  My name is [YOUR NAME], I am a resident of [YOUR DISTRICT]. I am demanding reallocation of funding from LBPD to social and public programming that takes place in our communities. It is an outrage that 48.3% of the city funding for 2021 is planned to be allocated to the Police Department and that Chief Luna’s salary is equivalent to that of the president of the United States.
 
   I demand that the City Council meaningfully defund the LBPD. I join the calls of those across the country to defund the police. I am demanding a budget that adequately and effectively meets the needs of at-risk Long Beach residents during this trying and uncertain time, when livelihoods are on the line. I am demanding a budget that supports community wellbeing, rather than empowering the police forces that tear them apart.
 
   It is your duty to represent your constituents. I am urging you to completely revise the Long Beach city budget for 2020-2021 fiscal year, and to fund the social programs long proven to be much more effective than policing at promoting community safety and equity. Public opinion is with me.
 
   Thank you for your time,
-  \[YOUR NAME\]
-  \[ADDRESS\]
-  \[PHONE NUMBER\]
-  \[EMAIL\]
+  [YOUR NAME]
+  [ADDRESS]
+  [PHONE NUMBER]
+  [EMAIL]
 ---
 

--- a/_emails/us/california/redwoodcity.md
+++ b/_emails/us/california/redwoodcity.md
@@ -17,7 +17,7 @@ subject: Redwood City Resident for Defunding the RCPD
 body: |-
   To Mayor Howard, Vice Mayor Masur, and Redwood City City Council Members,
 
-  My name is \[YOUR NAME\], and I am a resident of Redwood City. This past week, our nation and community have been gripped by protests calling for an end to racism and anti-Blackness and a complete overhaul in our approach to criminal justice in America. I am writing to demand real change to the Redwood City criminal justice system.
+  My name is [YOUR NAME], and I am a resident of Redwood City. This past week, our nation and community have been gripped by protests calling for an end to racism and anti-Blackness and a complete overhaul in our approach to criminal justice in America. I am writing to demand real change to the Redwood City criminal justice system.
 
   In the city’s recommended FY 2020-21 operating budget, $48.9M is allocated to the police, up from $46.5M in the FY 2019-20 budget. In comparison, the recommended budget only allocates $480k to affordable housing. Research shows that a living wage, access to health services and treatment including mental health services, educational opportunity, and stable housing are far more successful at promoting safe and equitable communities than punitive systems like police or prisons.
 
@@ -30,10 +30,10 @@ body: |-
   It is your duty to represent your constituents. I am urging you to revise the Redwood City recommended operating budget for FY 2020-21, and to increase funds to non-punitive community efforts.
 
   Thank you for your time,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
 

--- a/_emails/us/california/richmond.markdown
+++ b/_emails/us/california/richmond.markdown
@@ -20,7 +20,7 @@ subject: Richmond Resident for Defunding the RPD
 body: |-
   To Mayor Butt, the Richmond Board of Supervisors, and Richmond Elected Officers,
 
-  My name is \[YOUR NAME\], and I am a resident of Richmond. This past week, our nation has been gripped by protests calling for rapid and meaningful reevaluation of the role of policing in our communities and an end to racism and anti-Blackness. Our city has been at the forefront of much of this action. Accordingly, it has come to my attention that the budget for 2021 is being decided as these protests continue.
+  My name is [YOUR NAME], and I am a resident of Richmond. This past week, our nation has been gripped by protests calling for rapid and meaningful reevaluation of the role of policing in our communities and an end to racism and anti-Blackness. Our city has been at the forefront of much of this action. Accordingly, it has come to my attention that the budget for 2021 is being decided as these protests continue.
 
   RPD has been a waste of our resources. Last year, the RPD budget was $74,990,406, the majority of which comes from the Richmond general fund. While we’ve been spending extraordinary amounts on policing, we have not seen improvements to safety, homelessness, mental health, or affordability in our city. Instead, we see wasteful and harmful actions of our police.
 
@@ -30,9 +30,9 @@ body: |-
 
   Sincerely,
 
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 ---
 

--- a/_emails/us/california/sanfrancisco.md
+++ b/_emails/us/california/sanfrancisco.md
@@ -34,7 +34,7 @@ subject: San Francisco Resident for Defunding the SFPD
 body: |-
   To Mayor Breed, the San Francisco Board of Supervisors, and San Francisco Elected Officers
 
-  My name is \[YOUR NAME\], and I am a resident of San Francisco. This past week, our nation has been gripped by protests calling for rapid and meaningful change with regard to police behavior, an end to racism and anti-Blackness, and immediate reform in how Black people are treated in America. Our city has been at the forefront of much of this action. Accordingly, it has come to my attention that the budget for 2021 is being decided as these protests continue.
+  My name is [YOUR NAME], and I am a resident of San Francisco. This past week, our nation has been gripped by protests calling for rapid and meaningful change with regard to police behavior, an end to racism and anti-Blackness, and immediate reform in how Black people are treated in America. Our city has been at the forefront of much of this action. Accordingly, it has come to my attention that the budget for 2021 is being decided as these protests continue.
 
   SFPD has been a waste of our resources. Last year, the SFPD budget was $611,701,869, the majority of which comes from the San Francisco general fund. While we've been spending extraordinary amounts on policing, we have not seen improvements to safety, homelessness, mental health, or affordability in our city. Instead, we see wasteful and harmful actions of our police.
 
@@ -44,13 +44,12 @@ body: |-
 
   Sincerely,
 
-  \[YOUR NAME\]
+  [YOUR NAME]
 
-  \[YOUR ADDRESS\]
+  [YOUR ADDRESS]
 
-  \[YOUR EMAIL\]
+  [YOUR EMAIL]
 
-  \[YOUR PHONE NUMBER\]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
-

--- a/_emails/us/california/sanjose.md
+++ b/_emails/us/california/sanjose.md
@@ -20,7 +20,7 @@ subject: Defund the Police Department
 body: |-
   Hello,
 
-  My name is \[YOUR NAME\] and I am a resident of San Jose. I am writing to demand that funding is reallocated from SJPD to social and public programming that takes place in our communities. It is an outrage that 44% of city funding goes towards the Police Department. The SJPD has seen a rise in overtime pay which, more often than not, is paid out to officers responsible for harassing the unhoused, and Black, Indigenous, and people of color.
+  My name is [YOUR NAME] and I am a resident of San Jose. I am writing to demand that funding is reallocated from SJPD to social and public programming that takes place in our communities. It is an outrage that 44% of city funding goes towards the Police Department. The SJPD has seen a rise in overtime pay which, more often than not, is paid out to officers responsible for harassing the unhoused, and Black, Indigenous, and people of color.
 
   We demand that the City Council defund the SJPD. We join the calls of those across the country to defund the police. We demand a budget that adequately and effectively meets the needs of at-risk San Jose residents during this trying and uncertain time, when livelihoods are on the line. We demand a budget that supports community wellbeing, rather than empowers police.
 
@@ -28,10 +28,10 @@ body: |-
 
   Thank you for your time,
 
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
 

--- a/_emails/us/colorado/fortcollins.md
+++ b/_emails/us/colorado/fortcollins.md
@@ -22,7 +22,7 @@ subject:
 body: |-
   To Mayor Troxell, the Fort Collins City Council, City Manager, and other city officials:
 
-  My name is \[YOUR NAME\], and I am a resident of Fort Collins. This past week, our nation has been gripped by protests calling for a rapid and meaningful reconsideration of the role of policing in communities as well as an end to racism and anti-Blackness in America. Although Fort Collins is not at the forefront of these protests, it is not exempt from the racism and violence of the police system.
+  My name is [YOUR NAME], and I am a resident of Fort Collins. This past week, our nation has been gripped by protests calling for a rapid and meaningful reconsideration of the role of policing in communities as well as an end to racism and anti-Blackness in America. Although Fort Collins is not at the forefront of these protests, it is not exempt from the racism and violence of the police system.
 
   Fort Collins, Colorado also has a history of police violence against community members in addition to gentrification that has pushed communities farther away from central Fort Collins to floodplains and railroad tracks. Natasha Patnode was beaten by Fort Collins Police Officer Todd Hopkins in 2018. This ended up in an excessive-use-of-force settlement. In 2017, Michaella Surat, a former CSU student, was subjected to excessive force by officer Randall Klamser, as well as having her constitutional rights violated by unreasonable search and seizure.
 
@@ -32,9 +32,9 @@ body: |-
 
   Sincerely,
 
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 ---
 

--- a/_emails/us/colorado/pueblo.md
+++ b/_emails/us/colorado/pueblo.md
@@ -31,9 +31,9 @@ body: |-
 
   Thank you for your time,
 
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 ---
 

--- a/_emails/us/georgia/atlanta.md
+++ b/_emails/us/georgia/atlanta.md
@@ -8,10 +8,10 @@ recipients:
 - cebell@atlantaga.gov
 - sagabriel@atlantaga.gov
 subject: Please decrease Atlanta's Police Department’s budget
-body: "Hi, my name is \\[NAME\\] and I am a resident of \\[NEIGHBORHOOD\\]. I am asking
+body: "Hi, my name is [NAME] and I am a resident of [NEIGHBORHOOD]. I am asking
   to redirect money away from the Atlanta PD and into the following social services:
-  \\[LIST - Community Development, COVID Relief, Education, Parks & Recreation, targeted
-  support for marginalized communities\\]. \n\nI have noticed that in the 2021 budget
+  [LIST - Community Development, COVID Relief, Education, Parks & Recreation, targeted
+  support for marginalized communities]. \n\nI have noticed that in the 2021 budget
   proposal, from the general fund, the police department is receiving a 5.90% increase
   from 2020. Meanwhile, many other services are receiving cuts to their budgets. In
   light of recent events, I believe it is critical that policing be deprioritized
@@ -19,8 +19,8 @@ body: "Hi, my name is \\[NAME\\] and I am a resident of \\[NEIGHBORHOOD\\]. I am
   and equitable communities.\n\nI request that an emergency meeting be called before
   the fiscal year goes into effect in order to deny the mayor's proposed budget and
   reallocate these funds to resources the citizens can benefit from.\n\nThank you
-  for your time,\n\n\\[YOUR NAME\\]\n\\[YOUR ADDRESS\\]\n\\[YOUR EMAIL\\]\n\\[YOUR
-  PHONE NUMBER\\]"
+  for your time,\n\n[YOUR NAME]\n[YOUR ADDRESS]\n[YOUR EMAIL]\n[YOUR
+  PHONE NUMBER]"
 layout: email
 ---
 

--- a/_emails/us/maryland/baltimore.md
+++ b/_emails/us/maryland/baltimore.md
@@ -22,7 +22,7 @@ recipients:
 - Shannon.Sneed@baltimorecity.gov
 - MaryPat.Clarke@baltimorecity.gov
 subject: Commit to reallocate for social equity
-body: "\"To whom it may concern,\n\nMy name is \\[YOUR NAME\\], and I am a Baltimore
+body: "\"To whom it may concern,\n\nMy name is [YOUR NAME], and I am a Baltimore
   resident. In the midst of this pandemic and public outcry against police brutality,
   it feels especially inappropriate to propose an increase to the BPD budget to $545
   million. I urge you to ethically reallocate this increase, as well as a meaningful
@@ -40,7 +40,7 @@ body: "\"To whom it may concern,\n\nMy name is \\[YOUR NAME\\], and I am a Balti
   net, and racial and economic justice. I am writing to insist that the upcoming BBMR
   budget hearings for FY 2021 reflect the voices and needs of Baltimore’s citizens.
   I am asking that city officials give intense care, attention and effort towards
-  sustainable, long-term change.\n\nThank you,\n\\[YOUR NAME\\]\n\\[YOUR ADDRESS\\]\n\\[YOUR
-  EMAIL\\]\n\\[YOUR PHONE NUMBER\\]\""
+  sustainable, long-term change.\n\nThank you,\n[YOUR NAME]\n[YOUR ADDRESS]\n[YOUR
+  EMAIL]\n[YOUR PHONE NUMBER]\""
 ---
 

--- a/_emails/us/michigan/annarbor.md
+++ b/_emails/us/michigan/annarbor.md
@@ -20,17 +20,17 @@ subject: Defund Ann Arbor Police Department
 body: |-
   Mayor Taylor and City Council members,
 
-  My name is \[YOUR NAME\] and I am a resident of \[NEIGHBORHOOD/BOROUGH/CITY\]. Given the history of policing and the most recent murders of Black people, I am asking you to redirect money away from the Ann Arbor PD in the 2021 budget and instead to prioritize services that help strengthen our communities.
+  My name is [YOUR NAME] and I am a resident of [NEIGHBORHOOD/BOROUGH/CITY]. Given the history of policing and the most recent murders of Black people, I am asking you to redirect money away from the Ann Arbor PD in the 2021 budget and instead to prioritize services that help strengthen our communities.
 
   I want a budget that reflects our community's priorities and needs. In 2020, the City of Ann Arbor's Budget showed that 27% of the general fund was allocated to policing while only 16% was allocated to community services and only 6% to public services. We want Ann Arbor PD's funding redistributed to services that actually help the people of Ann Arbor, including affordable housing, more mental health services, and rent suspension and forgiveness for those who are currently unemployed. Beyond policing our community, these services are proven to be more effective in improving community safety and wellness. I demand a budget that supports community wellbeing, rather than giving power to police forces that tear us apart.
 
   Please consider your role in enriching and empowering our communities, especially amidst systemic racial injustice, wide-spread illness, and economic vulnerability.
 
   Thank you,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
 

--- a/_emails/us/minnesota/minneapolis.md
+++ b/_emails/us/minnesota/minneapolis.md
@@ -7,8 +7,8 @@ state: MN
 recipients:
 - jacob.frey@minneapolismn.gov
 subject: Defund the Minneapolis Police Department
-body: "Dear Mayor Frey and City Council Members,\n\nMy name is \\[YOUR NAME\\]. I
-  am a resident of \\[YOUR CITY, STATE\\] and I am emailing today to demand the defunding
+body: "Dear Mayor Frey and City Council Members,\n\nMy name is [YOUR NAME]. I
+  am a resident of [YOUR CITY, STATE] and I am emailing today to demand the defunding
   of the Minneapolis Police Department and the funding of new, community-led and integrated
   health and safety strategies.\n\nWe are in the midst of widespread upheaval over
   the systemic, racist violence which has been, to this point, overseen by the Minneapolis
@@ -23,8 +23,8 @@ body: "Dear Mayor Frey and City Council Members,\n\nMy name is \\[YOUR NAME\\]. 
   residents during the pandemic and well past it; and we need a budget that supports
   communities and supports their well-being. \n\nI am urging you and the Minneapolis
   City Council to adopt a budget that defunds the police and funds non-violent, community-led,
-  health and safety strategies.\n\nSincerely,\\\n\\[YOUR NAME\\]\n\\[YOUR ADDRESS\\]\n\\[YOUR
-  EMAIL\\]\n\\[YOUR PHONE NUMBER\\]"
+  health and safety strategies.\n\nSincerely,\\\n[YOUR NAME]\n[YOUR ADDRESS]\n[YOUR
+  EMAIL]\n[YOUR PHONE NUMBER]"
 cc:
 - kevin.reich@minneapolismn.gov
 - cam.gordon@minneapolismn.gov

--- a/_emails/us/montana/billings.md
+++ b/_emails/us/montana/billings.md
@@ -8,8 +8,8 @@ state: MT
 recipients:
 - council@billingsmt.gov
 subject: Billings demands a budget for justice and social equity
-body: "To the Billings City Council,\n\nMy name is \\[YOUR NAME\\] and I am a resident
-  of \\[YOUR WARD\\]. I am writing to demand that the City Council adopts a budget
+body: "To the Billings City Council,\n\nMy name is [YOUR NAME] and I am a resident
+  of [YOUR WARD]. I am writing to demand that the City Council adopts a budget
   that prioritizes community well-being and redirects funding away from the police.\n\nMany
   Montanans may be tempted to think the unique nature of such a vast, yet sparsely-populated
   state minimizes the likelihood of police brutality in our small city communities.
@@ -35,7 +35,6 @@ body: "To the Billings City Council,\n\nMy name is \\[YOUR NAME\\] and I am a re
   I am urging you to completely revise the budget for the 2020-2021 fiscal year, and
   to fund the social programs proven to be more effective than policing at promoting
   community safety and equity. Have the courage to be a leader of the change this
-  city, state, and country desperately needs.\n\nThank you for your time,\n\\[YOUR
-  NAME\\] \n\\[YOUR ADDRESS\\] \n\\[YOUR EMAIL\\] \n\\[YOUR PHONE NUMBER\\]"
+  city, state, and country desperately needs.\n\nThank you for your time,\n[YOUR
+  NAME] \n[YOUR ADDRESS] \n[YOUR EMAIL] \n[YOUR PHONE NUMBER]"
 ---
-

--- a/_emails/us/montana/butte.md
+++ b/_emails/us/montana/butte.md
@@ -11,7 +11,7 @@ subject: 'Butte demands a budget for justice '
 body: |-
   Dear Butte-Silver Bow Commissioners,
 
-  My name is \[YOUR NAME\] and I am a resident of \[YOUR WARD\]. I am writing to demand that the Council adopts a budget that prioritizes community well-being and redirects funding away from the police.
+  My name is [YOUR NAME] and I am a resident of [YOUR WARD]. I am writing to demand that the Council adopts a budget that prioritizes community well-being and redirects funding away from the police.
 
   Many Montanans may be tempted to think the unique nature of such a vast, yet sparsely-populated state minimizes the likelihood of police brutality in our small city communities. However, as reported by the Billings Gazette last year, Montana ranked ninth in killings by police per capita. In 2017, the Great Falls Tribune reported Montana police killings reached a total higher than the previous six years. These figures are alarming, but don’t tell the full story. Under Montana Code § 2-6-102 and Article II, Section 10 of the Montana Constitution, police disciplinary records are exempt from disclosure if there is an "individual privacy interest that clearly exceeds the merits of public disclosure." Montana police forces operate within a culture of impunity, and as the members of the communities they are supposed to be protecting, we can’t even begin to grasp the scope of their violence.
 
@@ -22,9 +22,9 @@ body: |-
   As commissioners, the budget proposal is in your hands. It is your duty to represent your constituents. I am urging you to completely revise the budget for the 2020-2021 fiscal year, and to fund the social programs proven to be more effective than policing at promoting community safety and equity. Have the courage to be a leader of the change this city, state, and country desperately needs.
 
   Thank you for your time,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 ---
 

--- a/_emails/us/montana/great-falls.md
+++ b/_emails/us/montana/great-falls.md
@@ -15,7 +15,7 @@ subject: Great Falls demands a budget for justice
 body: |-
   Dear Great Falls City Commissioners,
 
-  My name is \[YOUR NAME\] and I am a resident of \[YOUR DISTRICT\]. I am writing to demand that the City Commission adopts a budget that prioritizes community well-being and redirects funding away from the police.
+  My name is [YOUR NAME] and I am a resident of [YOUR DISTRICT]. I am writing to demand that the City Commission adopts a budget that prioritizes community well-being and redirects funding away from the police.
 
   Many Montanans may be tempted to think the unique nature of such a vast, yet sparsely-populated state minimizes the likelihood of police brutality in our small city communities. However, as reported by the Billings Gazette last year, Montana ranked ninth in killings by police per capita. In 2017, the Great Falls Tribune reported Montana police killings reached a total higher than the previous six years. These figures are alarming, but don’t tell the full story. Under Montana Code § 2-6-102 and Article II, Section 10 of the Montana Constitution, police disciplinary records are exempt from disclosure if there is an "individual privacy interest that clearly exceeds the merits of public disclosure." Montana police forces operate within a culture of impunity, and as the members of the communities they are supposed to be protecting, we can’t even begin to grasp the scope of their violence.
 
@@ -26,9 +26,9 @@ body: |-
   As the City Commission, the budget proposal is in your hands. It is your duty to represent your constituents. I am urging you to completely revise the budget for the upcoming fiscal year, and to fund the social programs proven to be more effective than policing at promoting community safety and equity. Have the courage to be a leader of the change this city, state, and country desperately needs.
 
   Thank you for your time,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 ---
 

--- a/_emails/us/montana/helena.md
+++ b/_emails/us/montana/helena.md
@@ -11,7 +11,7 @@ subject: Helena demands a budget for justice
 body: |-
   Dear Helena City Commission,
 
-  My name is \[YOUR NAME\] and I am a resident of \[YOUR DISTRICT\]. I am writing to demand that the City Commission adopts a budget that prioritizes community well-being and redirects funding away from the police.
+  My name is [YOUR NAME] and I am a resident of [YOUR DISTRICT]. I am writing to demand that the City Commission adopts a budget that prioritizes community well-being and redirects funding away from the police.
 
   Many Montanans may be tempted to think the unique nature of such a vast, yet sparsely-populated state minimizes the likelihood of police brutality in our small city communities. However, as reported by the Billings Gazette last year, Montana ranked ninth in killings by police per capita. In 2017, the Great Falls Tribune reported Montana police killings reached a total higher than the previous six years. These figures are alarming, but don’t tell the full story. Under Montana Code § 2-6-102 and Article II, Section 10 of the Montana Constitution, police disciplinary records are exempt from disclosure if there is an "individual privacy interest that clearly exceeds the merits of public disclosure." Montana police forces operate within a culture of impunity, and as the members of the communities they are supposed to be protecting, we can’t even begin to grasp the scope of their violence.
 
@@ -22,9 +22,9 @@ body: |-
   As the City Commission, the budget proposal is in your hands. It is your duty to represent your constituents. I am urging you to completely revise the budget for the 2020-2021 fiscal year, and to fund the social programs proven to be more effective than policing at promoting community safety and equity. Have the courage to be a leader of the change this city, state, and country desperately needs.
 
   Thank you for your time,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 ---
 

--- a/_emails/us/montana/kalispell.md
+++ b/_emails/us/montana/kalispell.md
@@ -11,7 +11,7 @@ subject: Kalispell demands a budget for justice
 body: |-
   To the Kalispell City Council,
 
-  My name is \[YOUR NAME\] and I am a resident of \[YOUR DISTRICT\]. I am writing to demand that the City Council adopts a budget that prioritizes community well-being and redirects funding away from the police.
+  My name is [YOUR NAME] and I am a resident of [YOUR DISTRICT]. I am writing to demand that the City Council adopts a budget that prioritizes community well-being and redirects funding away from the police.
 
   Many Montanans may be tempted to think the unique nature of such a vast, yet sparsely-populated state minimizes the likelihood of police brutality in our small city communities. However, as reported by the Billings Gazette last year, Montana ranked ninth in killings by police per capita. In 2017, the Great Falls Tribune reported Montana police killings reached a total higher than the previous six years. These figures are alarming, but don’t tell the full story. Under Montana Code § 2-6-102 and Article II, Section 10 of the Montana Constitution, police disciplinary records are exempt from disclosure if there is an "individual privacy interest that clearly exceeds the merits of public disclosure." Montana police forces operate within a culture of impunity, and as the members of the communities they are supposed to be protecting, we can’t even begin to grasp the scope of their violence.
 
@@ -22,9 +22,9 @@ body: |-
   As the City Council, the budget proposal is in your hands. It is your duty to represent your constituents. I am urging you to completely revise the budget for the 2020-2021 fiscal year, and to fund the social programs proven to be more effective than policing at promoting community safety and equity. Have the courage to be a leader of the change this city, state, and country desperately needs.
 
   Thank you for your time,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 ---
 

--- a/_emails/us/montana/missoula.md
+++ b/_emails/us/montana/missoula.md
@@ -8,8 +8,8 @@ state: MT
 recipients:
 - 'council@ci.missoula.mt.us '
 subject: Missoula demands a budget for justice
-body: "To the Missoula City Council,\n\nMy name is \\[YOUR NAME\\] and I am a resident
-  of \\[YOUR WARD\\]. I am writing to demand that the City Council adopts a budget
+body: "To the Missoula City Council,\n\nMy name is [YOUR NAME] and I am a resident
+  of [YOUR WARD]. I am writing to demand that the City Council adopts a budget
   that prioritizes community well-being and redirects funding away from the police.\n\nMany
   Montanans may be tempted to think the unique nature of such a vast, yet sparsely-populated
   state minimizes the likelihood of police brutality in our small city communities.
@@ -35,7 +35,7 @@ body: "To the Missoula City Council,\n\nMy name is \\[YOUR NAME\\] and I am a re
   to completely revise the budget for the 2020-2021 fiscal year, and to fund the social
   programs proven to be more effective than policing at promoting community safety
   and equity. Have the courage to be a leader of the change this city, state, and
-  country desperately needs.\n\nThank you for your time,\n\\[YOUR NAME\\] \n\\[YOUR
-  ADDRESS\\] \n\\[YOUR EMAIL\\] \n\\[YOUR PHONE NUMBER\\]"
+  country desperately needs.\n\nThank you for your time,\n[YOUR NAME] \n[YOUR
+  ADDRESS] \n[YOUR EMAIL] \n[YOUR PHONE NUMBER]"
 ---
 

--- a/_emails/us/nevada/reno.md
+++ b/_emails/us/nevada/reno.md
@@ -27,10 +27,10 @@ body: |-
   Our community is in pain along with the nation. We desperately need a reevaluation of our city's priorities.
 
   Thank you for your time,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
 

--- a/_emails/us/new_york/broome.md
+++ b/_emails/us/new_york/broome.md
@@ -24,13 +24,13 @@ subject: Commit to Reallocation for Social Equity
 body: |-
   Dear Broome County Legislature,
 
-  My name is \[YOUR NAME\] and I am a resident of \[YOUR NEIGHBORHOOD/DISTRICT\]. I am asking the County Legislature to begin meaningfully defunding the Broome County Police Department and re-allocate those funds to programs proven to more effectively promote a safe and equitable community: community-based mental health services, substance abuse treatment services, affordable housing programs, and more. I demand a budget that reflects the actual needs of Broome County residents. Much scholarship shows that a living wage, access to health services and treatment, educational opportunity, and stable housing are far more successful at promoting community safety than policing and prisons. As such, I demand a meaningful reallocation of police department funds towards healthcare and social programs.
+  My name is [YOUR NAME] and I am a resident of [YOUR NEIGHBORHOOD/DISTRICT]. I am asking the County Legislature to begin meaningfully defunding the Broome County Police Department and re-allocate those funds to programs proven to more effectively promote a safe and equitable community: community-based mental health services, substance abuse treatment services, affordable housing programs, and more. I demand a budget that reflects the actual needs of Broome County residents. Much scholarship shows that a living wage, access to health services and treatment, educational opportunity, and stable housing are far more successful at promoting community safety than policing and prisons. As such, I demand a meaningful reallocation of police department funds towards healthcare and social programs.
 
   Sincerely,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
 

--- a/_emails/us/new_york/buffalo.md
+++ b/_emails/us/new_york/buffalo.md
@@ -17,7 +17,7 @@ recipients:
 - rwyatt@city-buffalo.com
 subject: Buffalo Police Department Budget Reform and Action Plan
 body: "To the Buffalo Common Council and Office of Mayor Byron Brown,\n\nMy name is
-  \\[YOUR NAME\\] and I am a resident of \\[YOUR NEIGHBORHOOD\\]. I am imploring you
+  [YOUR NAME] and I am a resident of [YOUR NEIGHBORHOOD]. I am imploring you
   to meaningfully restrict the Buffalo Police Department's $121.9 million dollar budget
   immediately. On June 5, Buffalo Police officers pushed a non-violent 75 year old
   man to the ground while he was exercising his first amendment rights. In case you
@@ -40,8 +40,8 @@ body: "To the Buffalo Common Council and Office of Mayor Byron Brown,\n\nMy name
   for economic growth, and programs that fight hunger and housing are proven to be
   more effective than police presence in improving community safety and wellness.
   \n\nHow will you show up for a city in desperate need of help? Spending $121.9 million
-  dollars on the Buffalo Police is not the solution.\n\nSincerely,\n\\[YOUR NAME\\]\n\\[YOUR
-  ADDRESS\\]\n\\[YOUR EMAIL\\]\n\\[YOUR PHONE NUMBER\\]\n\nPS: Their names are Quentin
+  dollars on the Buffalo Police is not the solution.\n\nSincerely,\n[YOUR NAME]\n[YOUR
+  ADDRESS]\n[YOUR EMAIL]\n[YOUR PHONE NUMBER]\n\nPS: Their names are Quentin
   Suttles. Wilson Morales. A former Erie County Sheriff's Deputy assaulted someone
   at a tailgate party and was found guilty of falsifying records. Pito Rivera. Devin
   Ford. Troy Hodge. Marcus Neal. Shaun Porter was brutally beaten while an inmate

--- a/_emails/us/new_york/westchester.md
+++ b/_emails/us/new_york/westchester.md
@@ -26,8 +26,8 @@ recipients:
 - tubiolo@westchesterlegislators.com
 - williams@westchesterlegislators.com
 subject: Reallocate police budget to social services
-body: "Dear Westchester County Legislature,\n\nMy name is \\[NAME\\] and I am a resident
-  of \\[TOWN\\]. I am asking you to reallocate money away from the Westchester County
+body: "Dear Westchester County Legislature,\n\nMy name is [NAME] and I am a resident
+  of [TOWN]. I am asking you to reallocate money away from the Westchester County
   Police Department. According to a 2018 report, Black people are the subjects of
   42% of all arrests in Westchester despite making up only 14% of our population (https://www.criminaljustice.ny.gov/crimnet/ojsa/comparison-population-arrests-prison-demographics/2018%20Population%20Arrests%20Prison%20by%20Race.pdf).
   Furthermore, Black people convicted of a crime in Westchester are sentenced to jail
@@ -37,8 +37,8 @@ body: "Dear Westchester County Legislature,\n\nMy name is \\[NAME\\] and I am a 
   research shows that a living wage, access to health services and treatment, educational
   opportunity, and stable housing are far more successful at promoting community safety
   than policing and prisons. As such, I demand a meaningful reallocation of police
-  department funds towards healthcare and social programs.\n\nSincerely,\n\n\\[YOUR
-  NAME\\]\n\n\\[YOUR ADDRESS\\]\n\n\\[YOUR EMAIL\\]\n\n\\[YOUR PHONE NUMBER\\]"
+  department funds towards healthcare and social programs.\n\nSincerely,\n\n[YOUR
+  NAME]\n\n[YOUR ADDRESS]\n\n[YOUR EMAIL]\n\n[YOUR PHONE NUMBER]"
 layout: email
 ---
 

--- a/_emails/us/north_carolina/charlotte.md
+++ b/_emails/us/north_carolina/charlotte.md
@@ -21,7 +21,7 @@ subject: Commit to reallocate for social equity / Defund the CMPD
 body: |-
   Dear Mayor Lyles, City Manager Jones, and Charlotte City Council,
 
-  My name is \[YOUR NAME\] and I am a resident of \[district/neighborhood\]. I write to express my concern that status quo funding of the CMPD is wholly inappropriate at a time when Charlotte residents ravaged by the economic impacts of the COVID-19 pandemic are in urgent need—not of further policing and criminalization, but of meaningful reprioritization towards their social wellbeing.
+  My name is [YOUR NAME] and I am a resident of [district/neighborhood]. I write to express my concern that status quo funding of the CMPD is wholly inappropriate at a time when Charlotte residents ravaged by the economic impacts of the COVID-19 pandemic are in urgent need—not of further policing and criminalization, but of meaningful reprioritization towards their social wellbeing.
 
   Specifically, Black Charlotteans have not only experienced disproportionate deaths from COVID-19, but have long been policed and incarcerated at rates far above their share of the population. The CMPD uses lethal force against Black residents over 3 times as often as white residents. Longstanding police tactics, as exemplified most recently by the violent repression of peaceful protests uptown, have been wrought against the interests of our city’s wellbeing. As such, a CMPD that siphons over 40% of the city’s general fund is unacceptable.
 
@@ -30,10 +30,10 @@ body: |-
   I implore you to advocate for the revision of the 2021 budget, for a meaningful reduction in the proposed $290,200,000 allocated for policing from the general fund, and a reallocation of these funds towards housing, education, and targeted support for marginalized communities.
 
   Thank you for your attention,
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
 

--- a/_emails/us/north_carolina/durham.md
+++ b/_emails/us/north_carolina/durham.md
@@ -13,7 +13,7 @@ recipients:
 - Jillian.Johnson@durhamnc.gov
 - charlie.reece@durhamnc.gov
 subject: Defund the Durham Police & Reallocate Funds
-body: "Dear Mayor Schewel & City Council Members:\n\nMy name is \\[YOUR NAME\\]. I
+body: "Dear Mayor Schewel & City Council Members:\n\nMy name is [YOUR NAME]. I
   am a resident of Durham. I am writing to object to the allocation of over $70M to
   the Durham Police Department in the 2020-2021 city budget. It is indefensible to
   increase the police budget when city workers are experiencing layoffs and denial
@@ -41,8 +41,8 @@ body: "Dear Mayor Schewel & City Council Members:\n\nMy name is \\[YOUR NAME\\].
   none existed before. Almost all the current litany of Black men and women dead from
   police violence were non-violent, unarmed people, for whom armed police became the
   site of death and brutality. \n\nCan I count on you to consider an alternative budget
-  that puts a focus on social service programs?\n\nThank you,\n\\[YOUR NAME\\]\n\\[YOUR
-  ADDRESS\\]\n\\[YOUR EMAIL\\]\n\\[YOUR PHONE NUMBER\\]"
+  that puts a focus on social service programs?\n\nThank you,\n[YOUR NAME]\n[YOUR
+  ADDRESS]\n[YOUR EMAIL]\n[YOUR PHONE NUMBER]"
 layout: email
 ---
 

--- a/_emails/us/north_carolina/holly_springs.md
+++ b/_emails/us/north_carolina/holly_springs.md
@@ -39,8 +39,8 @@ body: "Dear Mayor Sears and Town Council,\n\nMy name is [NAME] and I am a reside
   need to create a space in which more mental health service providers, social       workers,
   victim/survivor advocates, religious leaders, neighbors, and friends - all of the
   people who really make up our       community - can look out for one another. Mayor
-  Sears, will you look out for me, and will you look out for us?\n\nThank you,\n\n\\[YOUR
-  NAME\\]\n\\[YOUR ADDRESS\\]\n\\[YOUR EMAIL\\]\n\\[YOUR PHONE NUMBER\\]"
+  Sears, will you look out for me, and will you look out for us?\n\nThank you,\n\n[YOUR
+  NAME]\n[YOUR ADDRESS]\n[YOUR EMAIL]\n[YOUR PHONE NUMBER]"
 layout: email
 ---
 

--- a/_emails/us/oklahoma/okc.md
+++ b/_emails/us/oklahoma/okc.md
@@ -16,8 +16,8 @@ recipients:
 - ward7@okc.gov
 - ward8@okc.gov
 subject: Defund the Oklahoma City Police Department
-body: "Dear Oklahoma City Mayor, City Council, and Manager, \n\nMy name is \\[YOUR
-  NAME\\] and I am a resident of \\[NEIGHBORHOOD/WARD\\]. The City of Oklahoma City
+body: "Dear Oklahoma City Mayor, City Council, and Manager, \n\nMy name is [YOUR
+  NAME] and I am a resident of [NEIGHBORHOOD/WARD]. The City of Oklahoma City
   must do better by its residents. I am urging you to divest from the criminalization
   of our communities and reduce police spending in the budget for the 2021 fiscal
   year. In May, City Manager Freeman formally proposed deep spending cuts due to the
@@ -38,7 +38,7 @@ body: "Dear Oklahoma City Mayor, City Council, and Manager, \n\nMy name is \\[YO
   It is time for OKC, its leaders, and residents to create a more equitable city for
   all of us. Have the moral clarity to create a budget focused on communities instead
   of investing in a racist and destructive institution. Defund the Oklahoma City Police
-  Department.\n\nThank you,\n\\[NAME\\]\n\\[ADDRESS\\]\n\\[EMAIL\\]\n\\[PHONE NUMBER\\]"
+  Department.\n\nThank you,\n[NAME]\n[ADDRESS]\n[EMAIL]\n[PHONE NUMBER]"
 layout: email
 ---
 

--- a/_emails/us/oklahoma/tulsa.md
+++ b/_emails/us/oklahoma/tulsa.md
@@ -20,8 +20,8 @@ recipients:
 - kfothergill@tulsacounty.org
 - rpeters@tulsacounty.org
 subject: Reallocate for Justice
-body: "Dear Tulsa City Council and County Commissioners,\n\nMy name is \\[YOUR NAME\\]
-  and I am a resident of \\[NEIGHBORHOOD/WARD\\].  The City of Tulsa must do better
+body: "Dear Tulsa City Council and County Commissioners,\n\nMy name is [YOUR NAME]
+  and I am a resident of [NEIGHBORHOOD/WARD].  The City of Tulsa must do better
   by its residents. I am urging you to divest from the criminalization of our community
   and reduce police spending in the budget for the 2021 fiscal year. The Tulsa City
   Council will review and discuss the Mayor’s proposed budget and must approve a budget
@@ -41,6 +41,6 @@ body: "Dear Tulsa City Council and County Commissioners,\n\nMy name is \\[YOUR N
   It is time for Tulsa, its leaders, and residents to create a more equitable city
   for ALL of us. Have the moral clarity to create a budget focused on communities
   instead of investing in a racist and destructive institution. Defund the Tulsa Police
-  Department.\n\nThank you, \n\\[NAME\\] \n\\[ADDRESS\\]\n\\[EMAIL\\]\n\\[PHONE NUMBER\\]"
+  Department.\n\nThank you, \n[NAME] \n[ADDRESS]\n[EMAIL]\n[PHONE NUMBER]"
 ---
 

--- a/_emails/us/washington_state/seattle.md
+++ b/_emails/us/washington_state/seattle.md
@@ -20,7 +20,7 @@ subject: Commit to Reallocation for Social Equity
 body: |-
   Dear Seattle City Leadership,
 
-  My name is \[YOUR NAME\] and I am a resident of \[YOUR DISTRICT\]. I am writing to demand that the City Council adopt a People’s Budget that prioritizes community wellbeing and redirects funding away from the police.
+  My name is [YOUR NAME] and I am a resident of [YOUR DISTRICT]. I am writing to demand that the City Council adopt a People’s Budget that prioritizes community wellbeing and redirects funding away from the police.
 
   We are in the midst of widespread upheaval over the systemic violence of policing, embodied by the SPD’s well documented history of murdering Black people. I will no longer accept empty gestures and suggestions of “reform.” I am  demanding that my voice be heard now, and that real change be made to the way this city allocates its resources.
 
@@ -34,10 +34,10 @@ body: |-
 
   Thank you for your time,
 
-  \[YOUR NAME\]
-  \[YOUR ADDRESS\]
-  \[YOUR EMAIL\]
-  \[YOUR PHONE NUMBER\]
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
 layout: email
 ---
 

--- a/_emails/us/wisconsin/milwaukee.markdown
+++ b/_emails/us/wisconsin/milwaukee.markdown
@@ -21,8 +21,8 @@ recipients:
 - Marina@milwaukee.gov
 - russell.stamper@milwaukee.gov
 subject: Defund MPD, Reallocate for Social Equity
-body: "Dear Milwaukee Council Members,\n\nMy name is \\[YOUR NAME\\] and I am a resident
-  of \\[NEIGHBORHOOD/CITY\\].\n\nI am extremely concerned with the City of Milwaukee’s
+body: "Dear Milwaukee Council Members,\n\nMy name is [YOUR NAME] and I am a resident
+  of [NEIGHBORHOOD/CITY].\n\nI am extremely concerned with the City of Milwaukee’s
   inordinate investment in the Milwaukee Police Department (MPD) at the expense of
   critical youth, education, and health services.\n\nI am asking that the Milwaukee
   Common Council make a more overt and visible commitment to racial justice. I ask
@@ -41,7 +41,7 @@ body: "Dear Milwaukee Council Members,\n\nMy name is \\[YOUR NAME\\] and I am a 
   actions will result in a healthier, more just society. I implore you to please listen
   to the needs of your constituents and take immediate action to address their concerns.\n\nCan
   I count on you to consider an alternative budget that puts a focus on social service
-  programs?\n\nThank you,\n\n\\[YOUR NAME\\]\n\\[YOUR ADDRESS\\]\n\\[YOUR EMAIL\\]\n\\[YOUR
-  PHONE NUMBER\\]"
+  programs?\n\nThank you,\n\n[YOUR NAME]\n[YOUR ADDRESS]\n[YOUR EMAIL]\n[YOUR
+  PHONE NUMBER]"
 ---
 


### PR DESCRIPTION
The extra `\` in front of `[` and `]` are not needed. Look at the other templates that work just fine. It was setting a bad example when everyone copy pastes these other templates.
    
This was done with a search and replace of the regex `\\+\]` with `]` and the similar for `[` on all .md and .markdown files. I went through to double check that it worked fine, I didn't see any mistakes.