### PR TITLE
make page always scrollable for diff content length across pages

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -11,6 +11,7 @@
 	-webkit-animation-name:$animation; animation-name:$animation;}
 
 // Resets and Universal Classes ================================================
+html { overflow-y: scroll }
 html, body {margin:0px; padding:0px; width:100%; overflow-x: hidden !important;}
 h1, h2, h3, h4, h5, h6 {margin:0px;}
 img {max-width:100%; border:0px;}


### PR DESCRIPTION
I noticed the page shifts horizontally bc there are different lengths of content if you jump between states. Some solutions are summarized here: https://aykevl.nl/2014/09/fix-jumping-scrollbar. 

I went with super light solution for now, before attempting other css tricks. The "downside" is that a scroll bar always appears even when the content is short. But since there are no sub routes, you will always land on the home page, which has enough content to be scrollable and the leftover scrollbar is hardly noticeable.

# Before

![before](https://user-images.githubusercontent.com/2534903/84088821-4ecbda00-a9a2-11ea-943b-0e526882c1d2.gif)

# After

![after](https://user-images.githubusercontent.com/2534903/84088827-51c6ca80-a9a2-11ea-939e-77398b18828b.gif)


## Home page (tested in Chrome, Safari, Brave, Firefox, and Edge)

(chrome)
![image](https://user-images.githubusercontent.com/2534903/84088298-0c55cd80-a9a1-11ea-8c63-fa486f0f7de2.png)

(chrome)
![image](https://user-images.githubusercontent.com/2534903/84088553-97cf5e80-a9a1-11ea-9635-5a0412e13853.png)

## Mobile - not affected

(chrome)
![IMG_1551](https://user-images.githubusercontent.com/2534903/84088493-7cfcea00-a9a1-11ea-8fa8-dbd86c9fd397.PNG)

(safari)
![IMG_1552](https://user-images.githubusercontent.com/2534903/84088499-7f5f4400-a9a1-11ea-9316-25b170e64d3b.PNG)

