### PR TITLE
run python tests via docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+name: CI
 on: [push]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,28 @@
-name: Lint
-
 on: [push]
 
 jobs:
-  eslint:
+  js-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: stefanoeb/eslint-action@1.0.2
-
-      - name: js-unit-tests
+  js-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: yarn install
+      - name: Test
         run: yarn test
+  py-markdown-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        uses: docker://docker
+        with:
+          args: docker build ./test/markdown/ --tag=markdown-tests:latest
+      - name: Test
+        uses: docker://docker
+        with:
+          args: docker run markdown-tests:latest


### PR DESCRIPTION
Alternate approach to https://github.com/defund12/defund12.org/pull/1034, to run the already-Dockerized markdown tests on CI (on every branch) - no worries about python dependencies, etc.

https://github.com/avimoondra/defund12.org/runs/752942165
![image](https://user-images.githubusercontent.com/2534903/84120582-e0f7d080-a9ea-11ea-9332-ae35241bd6e7.png)
