### PR TITLE
Add Albany, CA

### DIFF
--- a/_emails/us/california/albany.md
+++ b/_emails/us/california/albany.md
@@ -1,0 +1,34 @@
+---
+title: Albany, CA
+permalink: "/albany"
+name: Letter to the Mayor, City Council, City Attorney, and the Social & Economic Justice Commission
+state: CA
+city: Albany
+layout: email
+recipients:
+- citycouncil@albanyca.org
+- mbarnes@albanyca.org
+- npilch@albanyca.org
+- rnason@albanyca.org
+- pmcquaid@albanyca.org
+- pmaass@albanyca.org
+- msubramanian@albanyca.org
+- SEJC@albanyca.org
+subject: Albany Resident for Defunding the Albany Police
+body: |-
+  To Mayor Pilch, the Albany City Council, City Attorney, and the Social and Economic Justice Commission:
+
+  My name is [YOUR NAME], and I am a resident of Albany. These past weeks, our nation has been gripped by protests calling for a rapid and meaningful reconsideration of the role of policing in communities as well as an end to racism and anti-Blackness in America. Our neighbors have been at the forefront of much of this action.
+
+  At the same time, Albany Police has seen an increase in its share of funding over the years, with a worrying increase in the budget allocated for equipment. The 2019-20 budget allocated 30% to the police and only half of that to community development and services. The 2020-2021 budget proposes a ~10% increase in operations.
+
+  I call on you to slash the PD budget and instead meaningfully reallocate funds towards social programs and resources that support housing, jobs, education, health care, child care, and other critical community needs. I demand the discontinuation of the use of general fund dollars to pay for settlements due to police misconduct and negligence. I demand a budget that supports community wellbeing, rather than empowers the police forces that tear them apart.
+
+  We can be a beacon for other cities to follow if only we have the courage to change.
+
+  Sincerely,
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
+---


### PR DESCRIPTION
Closes #629 Should the permalink be albany_ca ? since this is the lesser know Albany? Just a question. I have it as just albany right now because Albany, NY has yet to be added.