### PR TITLE
Add Franklin Township, Somerset County, NJ

### DIFF
--- a/_emails/us/new_jersey/franklintownship.md
+++ b/_emails/us/new_jersey/franklintownship.md
@@ -1,0 +1,36 @@
+---
+title: Franklin Township, Somerset County, NJ
+permalink: "/franklintownship"
+name: Letter to the Mayor and Council
+state: NJ
+city: Franklin Township, Somerset County
+layout: email
+recipients:
+- Mayor.Kramer@franklinnj.gov
+- Councilman.Onyejiaka@franklinnj.gov
+- Councilman.Ram@franklinnj.gov
+- Councilwoman.Francois@franklinnj.gov
+- Councilwoman.Pruitt@franklinnj.gov
+- Councilman.Chase@franklinnj.gov
+- Councilman.Galtieri@franklinnj.gov
+- Councilman.Wright@franklinnj.gov
+- Councilman.Vassanella@franklinnj.gov
+- lrainone@njrcmlaw.com
+- annmarie.mccarthy@franklinnj.gov
+- Robert.Vornlocker@franklinnj.gov
+subject: [INSERT UNIQUE SUBJECT LINE]
+body: |-
+  Dear Mayor Kramer and Councilmembers:
+
+  My name is [YOUR NAME], and I am a resident of [TOWN/NEIGHBORHOOD]. In light of the urgent movement for Black lives happening across our nation, I am writing to urge you to advocate for a meaningful reallocation of the Township's expenditures away from policing, and towards social programs that more effectively meet critical community needs. I know that the Franklin Police Department have pledged to pursue more community policing initiatives. This is insufficient: the entire system of policing is broken and ineffective, and must be replaced with something else.
+
+  At $15,545,855 total, representing an increase from 2019, the Township’s amended 2020 budget for policing dwarfs its other appropriations. For example, the allocation for public works totals under $4 million, and the budget for health and human services does not even reach $1 million. If we really don’t need as much as $1 million for health and human services (doubtful, especially in light of the COVID-19 pandemic), how could we possibly need over $15 million for police? Franklin’s population is 28.1% African American. Given that racial inequities persist throughout the nation, and that police have proven to be a dire public health threat for Black Americans, it is unconscionable to continue to fund police at these disproportionate levels.
+
+  I urge you to advocate for a complete overhaul of the Township’s budget that directs at least $10 million away from policing. All over the country, concerned residents are calling for budgets that truly represent the people’s needs. In a global pandemic, it is all the more critical to invest funds in areas like “Community Resources/Public Assistance,” which is currently slated to receive less than $300,000. I urge you to revise the FY 2020 budget to reflect these demands, and show that Franklin Township is committed to true public safety for its Black population and all of its residents.
+
+  Thank you,
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
+---


### PR DESCRIPTION
Closes #761 A note on this PR. There is a Franklin, NJ as opposed to a Franklin Township, NJ. Also there are 4 Franklin Townships in NJ.  Source: https://en.wikipedia.org/wiki/Franklin_Township,_New_Jersey

I decided to include the county in the city and title lines because of the potential confusion. Thoughts?