### PR TITLE
Add Pittsburg, CA

### DIFF
--- a/_emails/us/california/pittsburg.md
+++ b/_emails/us/california/pittsburg.md
@@ -6,10 +6,9 @@ state: CA
 city: Pittsburg
 layout: email
 recipients:
-- killings@ci.pittsburg.ca.us
-- citycouncil@ci.pittsburg.ca.us
-subject:
-- INSERT UNIQUE SUBJECT LINE
+  - killings@ci.pittsburg.ca.us
+  - citycouncil@ci.pittsburg.ca.us
+subject: INSERT UNIQUE SUBJECT LINE
 body: |-
   Dear Mayor Killings and Pittsburg City Council Members,
 

--- a/_emails/us/california/pittsburg.md
+++ b/_emails/us/california/pittsburg.md
@@ -1,0 +1,37 @@
+---
+title: Pittsburg, CA
+permalink: "/pittsburg"
+name: Letter to the Mayor and City Council
+state: CA
+city: Pittsburg
+layout: email
+recipients:
+- killings@ci.pittsburg.ca.us
+- citycouncil@ci.pittsburg.ca.us
+subject:
+- INSERT UNIQUE SUBJECT LINE
+body: |-
+  Dear Mayor Killings and Pittsburg City Council Members,
+
+  My name is [YOUR NAME] and I am a resident of Pittsburg. Pittsburg Police Department takes an enormous share of the city’s general fund, taking away 61.53% of needed resources that can be allocated to essential programs and services in our city. I’m writing to you today to demand that Pittsburg support the redirection of significant funds back into the community for the 2020-2021 fiscal year.
+
+  Over the past fourteen days, our nation has been seized by protests calling for the systematic upheaval of institutions that promote racism and anti-Blackness, especially the institution that is the police, while also reimagining what community accountability can look like. While other Bay Area cities have been at the forefront of many of these protests, there have also been numerous outcries within Pittsburg. You may have witnessed these outcries through the 24 letters sent during the June 3rd city council meeting, through numerous posts all over social media, and through the peaceful demonstration outside of City Hall on Friday, June 5th.
+
+  Our city leaders must prioritize our community’s social programs, health care, housing, small businesses, and education. We must ensure that all students, especially black students and students of color, are equipped with the tools necessary to continue learning and thriving, rather than being stereotyped and heavily policed. Moreover, there is absolutely no reason a teacher must ask a student to bring basic school supplies when the funds distributed to the police department can be allocated to fulfill the needs of PUSD.
+
+  In addition to redirecting funds, we need to hold our local leaders accountable. Our Chief of Police, Brian Addington, failed to properly disclose documents in a case involving excessive force in 2014. We demand the resignation of Brian Addington in this formidable role.
+
+  As a Pittsburg resident, I demand that you take immediate action to ensure the following:
+
+  Reduce PPD’s allocation from the general fund by 50%.
+  Discontinue use of general fund dollars to pay for settlements due to police murder, misconduct, and negligence.
+  Invest in housing, jobs, youth programs, restorative justice, and mental health workers to keep the community safe.
+  Hold local leaders, like Police Chief Addington, and yourselves accountable.
+  I am urging you to completely revise the budget for the 2020-2021 fiscal year. Public opinion is with me.
+
+  Best,
+  [YOUR NAME]
+  [YOUR ADDRESS]
+  [YOUR EMAIL]
+  [YOUR PHONE NUMBER]
+---


### PR DESCRIPTION
Fixes #810 . permalink doesn't need state because the Pennsylvania Pittsburgh is a different spelling.