### PR TITLE
Remove comment blocks in email issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/EMAIL_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/EMAIL_REQUEST.md
@@ -7,7 +7,6 @@ labels: new-request
 assignees: ''
 ---
 
-<!--
 Hi, thanks for your interest in adding your city to the website. Emails on defund12.org are all written by community members. To add your city, you **must** provide:
 
 - Email addresses (at least one) of the government officials you’d like to receive the message
@@ -18,4 +17,3 @@ Hi, thanks for your interest in adding your city to the website. Emails on defun
 Messages should follow our [email style guidelines](https://github.com/defund12/defund12.org/blob/gh-pages/EMAIL_TEMPLATE_STYLE_GUIDE.md). Remember that messages must be specific to your locale and focused on defunding the police. If your message is copied from an external source, please provide a link to the original source.
 
 Your request will be **closed** until you reply with the necessary content. Thank you!
--->


### PR DESCRIPTION
We added the instructions in comment blocks so there would be less noise in the issue body when triaging. However, at least one submitter has put their finalized content _within_ the comment block, rendering us unable to see the work they did and leading us to close the issue.