### PR TITLE
Fix newlines for Android

### DIFF
--- a/_layouts/email.html
+++ b/_layouts/email.html
@@ -42,8 +42,13 @@
 
 <script type="text/javascript">
     function openEmail() {
+        const isAndroid = /(android)/i.test(navigator.userAgent);
         const subject = encodeURIComponent(`{{ site.default_subject_line }}`.trim());
-        const body = encodeURIComponent(`{{ page.body }}`.trim());
+        const body = encodeURIComponent(
+            isAndroid ?
+                `{{ page.body | newline_to_br }}`.trim() :
+                `{{ page.body }}`.trim()
+        );
         const recipients = `{{ page.recipients | join: ',' }}`;
         const cc = `{{ page.cc | join: ',' }}`;
         const ccText = cc !== null && cc.length > 0 ? `cc=${cc}&` : ``;


### PR DESCRIPTION
Closes #480.

## QA

Needs QA on Android and iOS.

Check any email to see if newlines are respected in the email client (`send email` link).

I set up a [subdomain](https://defund.dionlarson.com/) for QA so you don't need to set up anything locally! ❤️ 