### PR TITLE
Tweak email rendering HTML

### DIFF
--- a/_layouts/email.html
+++ b/_layouts/email.html
@@ -17,13 +17,13 @@
     <div class="container">
         <div class="emailContent">
             <div class="recipients">
-                <b>To:</b> {{ page.recipients | join: ', ' }}
-                <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.recipients | join: ', ' }}`)">🔗</span>
+                <b>To:</b> <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.recipients | join: ', ' }}`)">🔗</span>
+                {{ page.recipients | join: ', ' }}
             </div>
             {% if page.cc %}
             <div class="recipients">
-                <b>CC:</b> {{ page.cc | join: ', ' }}
-                <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.cc | join: ', ' }}`)">🔗</span>
+                <b>CC:</b> <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.cc | join: ', ' }}`)">🔗</span>
+                {{ page.cc | join: ', ' }}
             </div>
             {% endif %}
             <div class="recipients">

--- a/_layouts/email.html
+++ b/_layouts/email.html
@@ -30,7 +30,7 @@
                 <b>Subject:</b> {{ site.default_subject_line }}
             </div>
             <div>
-                <b>Message</b> <i>(Don't forget to replace the [x]'s with your information!)</i>
+                <b>Message:</b> <i>(Don't forget to replace the [x]'s with your information!)</i>
                 <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.body }}`)">🔗</span>
                 <br /> {{ page.body | markdownify }}
             </div>

--- a/_layouts/email.html
+++ b/_layouts/email.html
@@ -17,13 +17,13 @@
     <div class="container">
         <div class="emailContent">
             <div class="recipients">
-                <b>To:</b> {{ page.recipients | join: ',' }}
-                <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.recipients | join: ',' }}`)">🔗</span>
+                <b>To:</b> {{ page.recipients | join: ', ' }}
+                <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.recipients | join: ', ' }}`)">🔗</span>
             </div>
             {% if page.cc %}
             <div class="recipients">
-                <b>CC:</b> {{ page.cc | join: ',' }}
-                <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.cc | join: ',' }}`)">🔗</span>
+                <b>CC:</b> {{ page.cc | join: ', ' }}
+                <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.cc | join: ', ' }}`)">🔗</span>
             </div>
             {% endif %}
             <div class="recipients">


### PR DESCRIPTION
There were just a few tiny things that could be tweaked when the emails were displayed in HTML.

This is what it looks like afterwards, Chrome on OSX:
<img width="714" alt="Screen Shot 2020-06-10 at 11 33 17 PM" src="https://user-images.githubusercontent.com/10820686/84357939-e122d800-ab72-11ea-82ae-e7d9b894f305.png">
