### PR TITLE
UX anchor link underline color change

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -90,7 +90,7 @@ h2 {
 	@include breakpoint(s) {font-size:22px;}
 }
 a {
-	border-bottom:1px solid var(--subtle);
+	border-bottom:1px solid var(--link_subtle);
 	&:hover {
 		border-color: var(--subtle_);
 	}

--- a/css/main.scss
+++ b/css/main.scss
@@ -55,19 +55,21 @@ $pad_: 20px; // tablet and mobile
   --subtle: #ddd;
   --subtle_: #aaa;
   --link: blue;
+  --link_subtle: #acb9ce;
   --bg: #fff;
   --bg_: #f5f5f5;
-  --bg__: #fff; 
-  
+  --bg__: #fff;
+
   @media (prefers-color-scheme: dark) {
     --text: #ddd;
     --text_subtle: #666;
     --subtle: #353535;
     --subtle_: #555;
     --link: #3C81F9;
-    --bg:   #111;
-    --bg_:  #181818;
-    --bg__: #222222; 
+    --link_subtle: #435472;
+    --bg: #111;
+    --bg_: #181818;
+    --bg__: #222222;
   }
 }
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -101,7 +101,7 @@ a {
 }
 p.divider {
 	&:before {
-		content:""; display:block; width:48px; border-bottom:1px solid var(--subtle); margin-bottom:20px;
+		content:""; display:block; width:48px; border-bottom:1px solid var(--link_subtle); margin-bottom:20px;
 	}
 	line-height:1.6;
 	max-width:580px;


### PR DESCRIPTION
Looking to make the underline a little more accessible in light and dark desktop modes by creating a new css variable and slightly bumping up the contrast - as opposed to doing anything too radical.

Comparison screenshots below

## Light Mode
### Before
<img width="746" alt="defund12_before-light" src="https://user-images.githubusercontent.com/1668411/84409528-2b3ba600-abd3-11ea-916f-84a3d69a5409.png">

### After
<img width="746" alt="defund12_after-light" src="https://user-images.githubusercontent.com/1668411/84409667-53c3a000-abd3-11ea-82b9-c4f00a92c16d.png">

## Dark Mode
### Before
<img width="746" alt="defund12_before-dark" src="https://user-images.githubusercontent.com/1668411/84409526-2a0a7900-abd3-11ea-8f75-b4f66f3e2933.png">

### After
<img width="746" alt="defund12_after-dark" src="https://user-images.githubusercontent.com/1668411/84409661-52927300-abd3-11ea-9e66-005c097af602.png">