### PR TITLE
Update LA: Add Housing Dept /police bonus/LAPD PAC info

### DIFF
--- a/_emails/us/california/la.md
+++ b/_emails/us/california/la.md
@@ -22,6 +22,7 @@ recipients:
 - councilmember.huizar@lacity.org
 - councilmember.buscaino@lacity.org
 body: |
+  
   I am a resident of [YOUR DISTRICT]. I am writing to demand that the City Council adopt a People’s Budget that prioritizes community wellbeing and redirects funding away from the police. 
   
   We are in the midst of widespread upheaval over the systemic violence of policing, embodied by the LAPD’s well documented history of murdering Black people. 
@@ -30,25 +31,23 @@ body: |
   
   The current LAPD budget as it stands will be $3.14 billion, which is more than three times the budgets of housing, streets, and transportation, combined. We are in the midst of a pandemic with severe economic consequences. Over 50% of Angelenos are unemployed, and we can expect 42% lasting unemployment. Over 50% of those in this city are renters. When people are unemployed, they cannot pay rent. Prior to the pandemic, 60k people were unhoused; the evictions and economic insecurity caused by COVID-19 will bring that number even higher.
   
-  In 2017, Black people made up 9 percent of L.A. County’s general population but 40 percent of its homeless population. While Mayor Garcetti recognizes disproportionate impact of homelessness on Black people, he also slashed general fund spending for the Housing + Community Investment Department, which oversees the Proposition HHH program, by $1.2 million. Its staffers are among the 16,000 civilian employees who will be furloughed, while LAPD officers with college degrees will receive $41 million in bonuses. 
+  In 2017, Black people made up 9 percent of L.A. County’s general population but 40 percent of its homeless population. While Mayor Garcetti recognizes disproportionate impact of homelessness on Black people, he also slashed general fund spending for the Housing + Community Investment Department, which oversees the Proposition HHH program, by $1.2 million. The housing agency helps tenants facing eviction (it has reported receiving 500 calls every day during the pandemic), oversees a grocery-card program, and is putting together a $100 million fund that will help Angelenos pay their rent. Despite the critical services it delivers amid a public health crisis, its staffers are among the 16,000 civilian employees who will be furloughed, while LAPD officers with college degrees will receive $41 million in bonuses. 
   
-  The furloughs will threaten the Housing Department’s ability to complete the 1,025 apartments slated to open by this time next year as a part of the $1.2 billion plan to build 10,000 apartments for homeless residents over the course of a decade. Each of those apartments, costs the city $133,717 on average to construct. Reallocating the discretionary $1.86 billion going toward LAPD would truly save money as city revenue has been decimated by the pandemic. With the police budget, the city could instead help fund the construction of 14,000 additional long-term housing units for homeless Angelenos. In addition, the housing agency helps tenants facing eviction (it has reported receiving 500 calls every day during the pandemic), oversees a grocery-card program, and is putting together a $100 million fund that will help Angelenos pay their rent.
+  The furloughs will threaten the Housing Department’s ability to complete the 1,025 apartments slated to open by this time next year as a part of the $1.2 billion plan to build 10,000 apartments for homeless residents over the course of a decade. Each of those apartments costs the city $133,717 on average to construct, and with the discretionary police budget of $1.86 billion, the city could instead help fund the construction of 14,000 additional long-term housing units for homeless Angelenos. 
   
   From 2017-2020, the Los Angeles Police Protective League, contributed $396,666.12 to elect the following city council representatives:
 
-Gilbert Cedillo, District 1, $17,475.85 
-Paul Krekorian, District 2, $24,998.91
-David Ryu, District 4, $44,933.89
-Paul Koretz, District 5, $56,061.42
-Monica Rodriguez, District 7, $108,090.99
-Curren Price, District 9, $7,378.07
-Mike Bonin, District 11, $26,553.43
-John Lee, District 12, $83,072.44
-Mitch O'Farrell, District 13, $28,101.07
+  Gilbert Cedillo, District 1, $17,475.85 
+  Paul Krekorian, District 2, $24,998.91
+  David Ryu, District 4, $44,933.89
+  Paul Koretz, District 5, $56,061.42
+  Monica Rodriguez, District 7, $108,090.99
+  Curren Price, District 9, $7,378.07
+  Mike Bonin, District 11, $26,553.43
+  John Lee, District 12, $83,072.44
+  Mitch O'Farrell, District 13, $28,101.07
 
-Representatives must invest their LAPPL money in bail out funds, mutual aid, and organizations that benefit the black community in this pivotal time of tragedy and change. As a representative, it is your utmost duty to take a stand with your fellow community members, and make a pledge to not only reject any subsequent donations from the LAPPL, but to defund LAPD altogether. 
-
-  We join the calls of those across the country to #DefundThePolice. We demand a budget that adequately and effectively meets the needs of at-risk Angelenos during this trying and uncertain time, when livelihoods are on the line. We demand a budget that supports community wellbeing, rather than empowers the police forces that tear them apart.
+  Representatives must invest their LAPPL money in bail out funds, mutual aid, and organizations that benefit the black community in this pivotal time of tragedy and change. As a representative, it is your utmost duty to take a stand with your fellow community members, and make a pledge to not only reject any subsequent donations from the LAPPL, but to defund LAPD altogether. 
 
   We refuse to move towards a future in which senseless acts of violence at the hands of our police force go unheard, and we hope you honor George Floyd’s legacy to seek justice alongside us. City Council has avoided voting or revising Mayor Garcetti's draconian budget proposal, the document is back in your hands. It is your duty to represent your constituents. I am urging you to completely revise the LA budget for 2020-2021 fiscal year, and to fund #CareNotCops.  
 

--- a/_emails/us/california/la.md
+++ b/_emails/us/california/la.md
@@ -22,15 +22,35 @@ recipients:
 - councilmember.huizar@lacity.org
 - councilmember.buscaino@lacity.org
 body: |
-  I am a resident of [YOUR DISTRICT]. I am writing to demand that the City Council adopt a People’s Budget that prioritizes community wellbeing and redirects funding away from the police.
+  I am a resident of [YOUR DISTRICT]. I am writing to demand that the City Council adopt a People’s Budget that prioritizes community wellbeing and redirects funding away from the police. 
+  
+  We are in the midst of widespread upheaval over the systemic violence of policing, embodied by the LAPD’s well documented history of murdering Black people. 
+  
+  Despite having some of the best training in the nation, the LAPD has continued to display a history of being unable to deal with peaceful protestors. The violence of LAPD against largely peaceful protestors in beginning of June alone necessitates investigation: https://www.latimes.com/opinion/story/2020-06-09/excessive-lapd-protest-response. We will no longer accept empty gestures and suggestions of “reform.” This includes Mayor Garcetti's paltry 5% proposed cut with no clarity as to where these funds will be redirected, if at all. We are demanding that our voices be heard now, and that real change be made to the way this city allocates its resources. 
+  
+  The current LAPD budget as it stands will be $3.14 billion, which is more than three times the budgets of housing, streets, and transportation, combined. We are in the midst of a pandemic with severe economic consequences. Over 50% of Angelenos are unemployed, and we can expect 42% lasting unemployment. Over 50% of those in this city are renters. When people are unemployed, they cannot pay rent. Prior to the pandemic, 60k people were unhoused; the evictions and economic insecurity caused by COVID-19 will bring that number even higher.
+  
+  In 2017, Black people made up 9 percent of L.A. County’s general population but 40 percent of its homeless population. While Mayor Garcetti recognizes disproportionate impact of homelessness on Black people, he also slashed general fund spending for the Housing + Community Investment Department, which oversees the Proposition HHH program, by $1.2 million. Its staffers are among the 16,000 civilian employees who will be furloughed, while LAPD officers with college degrees will receive $41 million in bonuses. 
+  
+  The furloughs will threaten the Housing Department’s ability to complete the 1,025 apartments slated to open by this time next year as a part of the $1.2 billion plan to build 10,000 apartments for homeless residents over the course of a decade. Each of those apartments, costs the city $133,717 on average to construct. Reallocating the discretionary $1.86 billion going toward LAPD would truly save money as city revenue has been decimated by the pandemic. With the police budget, the city could instead help fund the construction of 14,000 additional long-term housing units for homeless Angelenos. In addition, the housing agency helps tenants facing eviction (it has reported receiving 500 calls every day during the pandemic), oversees a grocery-card program, and is putting together a $100 million fund that will help Angelenos pay their rent.
+  
+  From 2017-2020, the Los Angeles Police Protective League, contributed $396,666.12 to elect the following city council representatives:
 
-  We are in the midst of widespread upheaval over the systemic violence of policing, embodied by the LAPD’s well documented history of murdering Black people. We will no longer accept empty gestures and suggestions of “reform.” This includes Mayor Garcetti's paltry 5% proposed cut with no clarity as to where these funds will be redirected, if at all. We are demanding that our voices be heard now, and that real change be made to the way this city allocates its resources.
+Gilbert Cedillo, District 1, $17,475.85 
+Paul Krekorian, District 2, $24,998.91
+David Ryu, District 4, $44,933.89
+Paul Koretz, District 5, $56,061.42
+Monica Rodriguez, District 7, $108,090.99
+Curren Price, District 9, $7,378.07
+Mike Bonin, District 11, $26,553.43
+John Lee, District 12, $83,072.44
+Mitch O'Farrell, District 13, $28,101.07
 
-  We are in the midst of a pandemic with severe economic consequences. Over 50% of Angelenos are unemployed, and we can expect 42% lasting unemployment. Over 50% of those in this city are renters. When people are unemployed, they cannot pay rent. Prior to the pandemic, 60k people were unhoused; the evictions and economic insecurity caused by COVID-19 will bring that number even higher.
+Representatives must invest their LAPPL money in bail out funds, mutual aid, and organizations that benefit the black community in this pivotal time of tragedy and change. As a representative, it is your utmost duty to take a stand with your fellow community members, and make a pledge to not only reject any subsequent donations from the LAPPL, but to defund LAPD altogether. 
 
-  We demand that the City Council meaningfully defund the LAPD. We join the calls of those across the country to #DefundThePolice. We demand a budget that adequately and effectively meets the needs of at-risk Angelenos during this trying and uncertain time, when livelihoods are on the line. We demand a budget that supports community wellbeing, rather than empowers the police forces that tear them apart.
+  We join the calls of those across the country to #DefundThePolice. We demand a budget that adequately and effectively meets the needs of at-risk Angelenos during this trying and uncertain time, when livelihoods are on the line. We demand a budget that supports community wellbeing, rather than empowers the police forces that tear them apart.
 
-  Although City Council has avoided voting or revising Mayor Garcetti's draconian budget proposal, the document is back in your hands. It is your duty to represent your constituents. I am urging you to completely revise the LA budget for 2020-2021 fiscal year, and to fund #CareNotCops. You need to adopt a People’s Budget. Public opinion is with me.
+  We refuse to move towards a future in which senseless acts of violence at the hands of our police force go unheard, and we hope you honor George Floyd’s legacy to seek justice alongside us. City Council has avoided voting or revising Mayor Garcetti's draconian budget proposal, the document is back in your hands. It is your duty to represent your constituents. I am urging you to completely revise the LA budget for 2020-2021 fiscal year, and to fund #CareNotCops.  
 
   Thank you for your time,
 


### PR DESCRIPTION
-Mention of excessive force in June protests (https://www.latimes.com/california/story/2020-06-09/hundreds-were-arrested-for-peacefully-protesting-here-are-their-stories)
-Contextualizing LAPD's $3 billion/ discretionary $1.8 billion with housing efforts, furloughing workers/cutting money in a department that is serving immediate critical needs while police offers receive bonuses (https://la.curbed.com/2020/6/2/21277088/defund-police-los-angeles-lapd-budget)
-LAPD PAC contributions to city council elections (http://thefutureleft.com/carenotcops)