### PR TITLE
build jekyll on non-master branches to confirim build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,27 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+  rb-test-jekyll-build:
+    if: github.ref != 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - run: gem install bundler -v 2.1.4
+      - run: bundle config path vendor/bundle
+      - run: bundle install --jobs 4 --retry 3
+      - run: mkdir public
+      - run: bundle exec jekyll build --destination ./public
+        env:
+          JEKYLL_ENV: production
   js-lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closes [Add jekyll build to Github actions](https://github.com/defund12/defund12.org/issues/641)