### PR TITLE
cache yarn deps (and combine jest + lint jobs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,34 +36,25 @@ jobs:
       - run: bundle exec jekyll build --destination ./public
         env:
           JEKYLL_ENV: production
-  js-lint:
+  js-lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Build
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Lint
         run: yarn lint
-      - name: Notify deploy failed (#general)
-        if: failure() && github.ref == 'refs/heads/master'
-        uses: pullreminders/slack-action@v1.0.9
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.DEFUND12_SLACK_DEPLOY_BOT_TOKEN }}
-        with:
-          args: '{\"channel\":\"C014Q9PLEMC\",\"text\":\":warning: Failed to deploy <https://github.com/defund12/defund12.org/commit/${{ github.sha }}|latest commit> on `master` due to issues with `${{ github.job }}` job\"}'
-      - name: Notify deploy failed (#deploys)
-        if: failure() && github.ref == 'refs/heads/master'
-        uses: pullreminders/slack-action@v1.0.9
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.DEFUND12_SLACK_DEPLOY_BOT_TOKEN }}
-        with:
-          args: '{\"channel\":\"C0153GJV1GV\",\"text\":\":warning: Failed to deploy <https://github.com/defund12/defund12.org/commit/${{ github.sha }}|latest commit> on `master` due to issues with `${{ github.job }}` job\"}'
-  js-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: yarn install --frozen-lockfile
       - name: Test
         run: yarn test
       - name: Notify deploy failed (#general)
@@ -80,7 +71,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.DEFUND12_SLACK_DEPLOY_BOT_TOKEN }}
         with:
           args: '{\"channel\":\"C0153GJV1GV\",\"text\":\":warning: Failed to deploy <https://github.com/defund12/defund12.org/commit/${{ github.sha }}|latest commit> on `master` due to issues with `${{ github.job }}` job\"}'
-  py-markdown-tests:
+  py-markdown-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -107,7 +98,7 @@ jobs:
         with:
           args: '{\"channel\":\"C0153GJV1GV\",\"text\":\":warning: Failed to deploy <https://github.com/defund12/defund12.org/commit/${{ github.sha }}|latest commit> on `master` due to issues with `${{ github.job }}` job\"}'
   build-and-deploy:
-    needs: [js-lint, js-tests, py-markdown-tests]
+    needs: [js-lint-and-test, py-markdown-test]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Build
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Lint
         run: yarn lint
       - name: Test


### PR DESCRIPTION
see https://stackoverflow.com/questions/61010294/how-to-cache-yarn-packages-in-github-actions, slightly different than https://github.com/actions/cache/blob/master/examples.md#node---yarn bc it doesn't quite work.

Can go even further (caching node_modules), but we can revisit once we pin node version down. 