### PR TITLE
replace automatic redirect with call to action overlay

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ defaults:
     city: City
     state: State intials
     recipients:
-    - 
+    -
     subject: Email subject (mention defunding police dept.)
     body: Email message (remember to include placeholders for name)
 permalink: pretty
@@ -37,6 +37,7 @@ footer_text_instructions: Have the emails of your city government officials and 
 contact_email_footer: "[contact@defund12.org](mailto:contact@defund12.org)"
 default_subject_line: "[*** INSERT UNIQUE SUBJECT LINE ***]"
 auto_open_message: This page automatically opens a drafted email for you.
+open_message_button: Open drafted email
 bad_mailto_message: Email link not working correctly? You can copy and paste the recipients,
   subject and message individually below.
 url: https://defund12.org

--- a/_layouts/email.html
+++ b/_layouts/email.html
@@ -1,9 +1,17 @@
 {% include header.html %}
 
+<div class="alertBox">
+  <div class="overlay" onclick="hideAlertOverlay()"></div>
+  <div class="tabArea">
+    <div class="dismissAlert" onclick="hideAlertOverlay()">✕</div>
+    <div class="tabText">Send a {{ page.name }}:</div>
+    <div class="tabText tabTextLocation">{{ page.city }}, {{ page.state }}</div>
+    <button class="emailCTA" onclick="openEmail()">{{ site.open_message_button }}</button>
+  </div>
+</div>
 <section class="emailPageHeader">
   <h2>{{ page.name }}</h2>
   <b>{{ page.city }}, {{ page.state }}</b>{{ site.email_intro_text | markdownify }}
-  <p id="autoopen">{{ site.auto_open_message }}</p>
   <div class='buttons'>
     <a href="javascript:void(0);" onclick="openEmail()">Send email</a>
     <a href="javascript:void(0);" onclick="copyToClipboard(this, `{{ page.permalink }}`, true)">Copy link</a>
@@ -40,6 +48,10 @@
 {% include list.html %}
 
 <script type="text/javascript">
+  function hideAlertOverlay() {
+    $(".alertBox").fadeOut("fast");
+  }
+
   function openEmail() {
     const isAndroid = /(android)/i.test(navigator.userAgent);
     const subject = encodeURIComponent(`{{ site.default_subject_line }}`.trim());
@@ -55,14 +67,22 @@
   }
   $(document).ready(() => {
     const params = getParams(window.location.href)
+
+    // example: https://defund12.org/anchorage?browse
     if (params.browse !== undefined) {
-      $("#autoopen").hide()
+      $(".alertBox").hide();
       // Automatically updates the URL so if folks try to share, it will auto-open
       window.history.replaceState({}, document.title, `${window.location.origin}{{ page.permalink }}`)
     } else {
-      openEmail()
+    // example: https://defund12.org/anchorage
+      $(".alertBox").show();
+      $(".alertBox").css({ height: window.innerHeight });
     }
-  })
+  });
+
+  $( window ).resize(function() {
+    $(".alertBox").css({ height: window.innerHeight });
+  });
 </script>
 
 {% include footer.html %}

--- a/_sass/2-layout/_email.scss
+++ b/_sass/2-layout/_email.scss
@@ -46,3 +46,89 @@
 
 
 }
+
+.alertBox {
+  display: none;
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  min-height: -webkit-fill-available;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 1;
+
+  // On mobile, position alert on bottom of screen
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  @media (min-width: 600px) {
+    // On desktop/table, position alert in center of screen
+    align-items: center;
+  }
+
+  .overlay {
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    top: 0;
+    left: 0;
+    z-index: 2;
+  }
+  .tabArea {
+    z-index: 3;
+    background-color: white;
+    border-radius: 15px 15px 0 0;
+    min-height: 200px;
+    width: 100%;
+    padding: 40px 20px;
+    text-align: center;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+
+    position: relative;
+
+    @media (min-width: 600px) {
+      max-width: 80%;
+      border-radius: 15px;
+    }
+
+    @media (min-width: 768px) {
+      max-width: 500px;
+    }
+  }
+  .dismissAlert {
+    cursor: pointer;
+    font-size: 30px;
+    font-weight: 900;
+
+    width: 50px;
+    height: 50px;
+
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+  .tabText {
+    margin-bottom: 20px;
+  }
+  .tabTextLocation {
+    font-weight: bold;
+  }
+  .emailCTA { // button
+    cursor: pointer;
+    width: 80%;
+    max-width: 250px;
+    min-height: 50px;
+    background-color: steelblue;
+    color: white;
+    font-weight: bold;
+    font-size: 15px;
+    border-radius: 10px;
+    border: none;
+  }
+}

--- a/_sass/2-layout/_global.scss
+++ b/_sass/2-layout/_global.scss
@@ -43,6 +43,10 @@ a {
   }
 }
 
+button {
+  font-family: 'Source Code Pro', 'Helvetica', 'Arial', sans-serif;
+}
+
 em,
 i {
   font-weight: 400;


### PR DESCRIPTION
Hello! I'm opening this PR to propose a feature that also fixes this bug #1464 (where the email prompt continuously opened in mobile with every new browser restart).

Current behavior: When re-opening an individual city page, the site currently automatically opens the default email client (or prompts to select an email client from a list).

New behavior: When re-opening an individual city page, the site will present an overlay with text & open email button. Visually there is a full/transparent overlay over the entire page and a white panel with info and a clickable "open draft email" button and an exit button. Clicking on the transparent overlay will dismiss the overlay.

Reasoning: This behavior creates a user friendly experience, giving a clear warning before redirecting into their email client and also presenting several easy ways to dismiss the warning.

**100% open to feedback on functionality, copy, design and any other notes from contributors. My main goal is to fix the bug but also to enhance user experience.**

## Mobile:
![alert-mobile](https://user-images.githubusercontent.com/1535040/84586124-8d1f2a00-ade4-11ea-9919-bb8191554dab.PNG)

## Desktop/Tablet:
![alert-desktop](https://user-images.githubusercontent.com/1535040/84586127-9d370980-ade4-11ea-89a1-1e24c6dd4c32.png)
