### PR TITLE
Corrected New Brunswick emails

### DIFF
--- a/_emails/us/new_jersey/new_brunswick.md
+++ b/_emails/us/new_jersey/new_brunswick.md
@@ -5,8 +5,7 @@ name: Letter to Mayor and City Council
 city: New Brunswick
 state: NJ
 recipients:
-- smith@cityofnewbrunswick.org
-- gfleming@cityofnewbrunswick.or
+- gfleming@cityofnewbrunswick.org
 - kegan@cityofnewbrunswick.org
 - janderson@cityofnewbrunswick.org
 - rescobar@cityofnewbrunswick.org


### PR DESCRIPTION
I corrected the missing 'g' at the end of gfleming's email address. Looking through the City of New Brunswick's website, I couldn't find anyone that the (bouncing) address smith@cityofnewbrunswick.org could refer to and the mayor's assistant and all city councilors are listed, so I deleted it. Fixes #1536.