### PR TITLE
Fix email preview (line breaks in signatures and styling for lists)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 node_modules/
 public/
 settings.json
+*.log

--- a/_sass/2-layout/_global.scss
+++ b/_sass/2-layout/_global.scss
@@ -98,6 +98,13 @@ p.divider {
   margin-bottom: $x_2;
 }
 
+ul, ol {
+  list-style: inherit;
+  max-width: 580px;
+  margin-left: $x_3;
+  margin-bottom: $x_2;
+}
+
 .copyToClipboard {
   cursor: pointer;
   opacity: 0.7;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "react-select": "^3.1.0",
         "rehype-sanitize": "^3.0.1",
         "rehype-stringify": "8.0.0",
+        "remark-breaks": "^1.0.5",
         "remark-parse": "^8.0.2",
         "remark-rehype": "^7.0.0",
         "tslint": "^6.1.2",

--- a/src/DefundUtils.ts
+++ b/src/DefundUtils.ts
@@ -1,5 +1,6 @@
 import unified from "unified";
 import markdown from "remark-parse";
+import breaks from "remark-breaks";
 import rehype from "remark-rehype";
 import sanitize from "rehype-sanitize";
 import html from "rehype-stringify";
@@ -16,6 +17,7 @@ export class DefundUtils {
   static markdownToHTML(value: string): string {
     return unified()
       .use(markdown)
+      .use(breaks)
       .use(rehype)
       .use(sanitize)
       .use(html)

--- a/src/own.d.ts
+++ b/src/own.d.ts
@@ -1,2 +1,3 @@
 declare module "react-select";
 declare module "rehype-sanitize";
+declare module "remark-breaks";

--- a/yarn.lock
+++ b/yarn.lock
@@ -12835,6 +12835,11 @@ relay-runtime@9.1.0:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
 
+remark-breaks@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-1.0.5.tgz#e9785f8b174f45c05af542fbeb18354b766e1139"
+  integrity sha512-lr8+TlJI273NjEqL27eUthPYPTCgXEj4NaLbnazS3bQaQL2FySlsbtgo52gE36fE1gWeQgkn1VdmWsoT+uA7FA==
+
 remark-footnotes@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/remark-footnotes/-/remark-footnotes-1.0.0.tgz#9c7a97f9a89397858a50033373020b1ea2aad011"


### PR DESCRIPTION
## Description

Related to #1349. Does not fully close because issue cannot be fully addressed without a slight syntax change in email yaml files (see below).

- Adds `remark-breaks` to insert `<br>` on single line breaks (double line breaks creates new `<p>` tags). This helps the formatting of signatures especially when displayed on the website.
- Adds styling for `<ul>` and `<ol>` since lists are sometimes used in emails and get parsed into HTML.
- Adds log files to `.gitignore` since yarn started one for me.

### QA

I recommend trying a few emails out, but make sure to take a look at:
- `/anchorage`: list and single line break signatures.
    <details>
      <summary>Side-by-side screenshot</summary>
      <table>
        <tr valign="top">
          <td><b>New</b><img src="https://user-images.githubusercontent.com/1843883/84835188-07c49100-b001-11ea-9085-3006699ba589.png"></td>
          <td><b>Old</b><img src="https://user-images.githubusercontent.com/1843883/84836411-b36ee080-b003-11ea-8384-07d4ada27be2.png"></td>
        </tr>
      </table>
    </details>

- `/belmont`: double line break signatures, no change from production. Once #1349 is fully addressed, we can set up tests to enforce single line signatures only.

## Further Discussion

### `[]` Clashing with reference-style link syntax

We should move away from using `[]` for `[NAME]`, etc. I recommend using `{}` instead. `[]` are tokens in markdown and used in link syntax. `[][]` gets parsed as a [reference style link](https://daringfireball.net/projects/markdown/syntax#link). This means that our signatures get parsed as two reference links in a row (line breaks are ignored).

This is a step in the right direction and can be merged before email yamls are changed. I recommend we do it in two parts and warn email devs upon merging this PR:
1. merge this
2. announce syntax change active in 48 hours
3. merge email+test updates at 48 hours
4. reject non-conforming emails going forward