### PR TITLE
Added meta preview image generation using our defund12-image-api

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,7 @@ badMailtoMessage: Email link not working correctly? You can copy and paste the r
 url: https://defund12.org
 logoUrl: "/images/defund12.org.png"
 faviconUrl: "/favicon.svg"
+metaPreviewUrl: "https://defund12-image-api.now.sh/api/preview?"
 sass:
   sass_dir: _sass
   style: compressed

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -63,6 +63,7 @@ class _Layout extends React.Component<LayoutProps> {
   }
 }
 
+// todo: add separate template for email and for index/404 so prop types are more clearly defined
 /**
  * The site layout, which contains elements to
  * place in <head> through React Helmet.
@@ -82,6 +83,7 @@ export default function Layout(
             meta
             logoUrl
             faviconUrl
+            metaPreviewUrl
           }
         }
       `}
@@ -92,6 +94,11 @@ export default function Layout(
             props.pageTitle ? props.pageTitle : data.siteConfig.siteTitle
           }
           meta={props.meta ? props.meta : data.siteConfig.meta}
+          logoUrl={
+            props.metaQueryString
+              ? data.siteConfig.metaPreviewUrl + props.metaQueryString
+              : data.siteConfig.logoUrl
+          }
         >
           {props.children}
         </_Layout>

--- a/src/components/email/Email.tsx
+++ b/src/components/email/Email.tsx
@@ -3,7 +3,11 @@ import * as queryString from "query-string";
 import React from "react";
 import { DefundUtils } from "../../DefundUtils";
 import { EmailData } from "../../types/EmailData";
-import { EmailConfig, EmailProps } from "../../types/PropTypes";
+import {
+  EmailConfig,
+  EmailProps,
+  OptionalLayoutProps,
+} from "../../types/PropTypes";
 import Layout from "../common/Layout";
 import EmailList from "../email-list/EmailList";
 
@@ -25,8 +29,7 @@ export default class Email extends React.Component<
 > {
   siteConfig: EmailConfig;
   emailData: EmailData;
-  title: string;
-  meta: string;
+  layoutProps: OptionalLayoutProps;
   autoOpen = false;
 
   /**
@@ -37,8 +40,14 @@ export default class Email extends React.Component<
     super(props);
     this.siteConfig = this.props.data.siteConfig;
     this.emailData = this.props.data.markdownRemark.frontmatter;
-    this.title = `Defund 12 in ${this.emailData.city}, ${this.emailData.state}`;
-    this.meta = `Send a pre-written email directly to ${this.emailData.city}, ${this.emailData.state} officials`;
+    this.layoutProps = {
+      pageTitle: `Defund12 in ${this.emailData.city}, ${this.emailData.state}`,
+      meta: `Send a pre-written email directly to ${this.emailData.city}, ${this.emailData.state} officials`,
+      metaQueryString: queryString.stringify({
+        state: this.emailData.state,
+        city: this.emailData.city,
+      }),
+    };
     this.state = new EmailState();
   }
 
@@ -98,7 +107,7 @@ export default class Email extends React.Component<
    */
   render(): React.ReactNode {
     return (
-      <Layout pageTitle={this.title} meta={this.meta}>
+      <Layout {...this.layoutProps}>
         <section className="emailPageHeader">
           <h2>{this.emailData.name}</h2>
           <b>

--- a/src/types/PropTypes.ts
+++ b/src/types/PropTypes.ts
@@ -27,12 +27,13 @@ export interface EmailProps {
 export interface OptionalLayoutProps {
   pageTitle?: string;
   meta?: string;
+  metaQueryString?: string;
 }
 
 // {Static query result properties}
 export type LayoutProps = Pick<
   SiteConfig,
-  "siteTitle" | "meta" | "faviconUrl" | "logoUrl"
+  "siteTitle" | "meta" | "faviconUrl" | "logoUrl" | "metaPreviewUrl"
 > &
   OptionalLayoutProps;
 

--- a/src/types/SiteConfig.ts
+++ b/src/types/SiteConfig.ts
@@ -9,6 +9,8 @@ export interface SiteConfig {
   logoUrl: string;
   /** A URL pointing to a favicon logo. */
   faviconUrl: string;
+  /** A URL pointing to the meta preview image generation API. */
+  metaPreviewUrl: string;
   /** A message that appears when an email is opened through a shared link. */
   autoOpenMessage: string;
   /**  */


### PR DESCRIPTION
this changes the meta tag to the url from the image generation api: ie. https://defund12-image-api.now.sh/api/preview?city=Sacramento&state=CA

we already hosted the api on vercel serverless, so the api shouldn't have any quotas, and hence, should be quite reliable

replaces #1629 