### PR TITLE
Ignore Lint Warning for No Explicit Any

### DIFF
--- a/src/components/email-list/EmailList.tsx
+++ b/src/components/email-list/EmailList.tsx
@@ -27,8 +27,7 @@ export interface EmailListState {
 class _EmailList extends React.Component<EmailListProps, EmailListState> {
   stateOptions: Array<ReactSelectOption>;
   selectStyles = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    option: (provided: any) => ({
+    option: (provided: React.CSSProperties) => ({
       ...provided,
       color: "black",
     }),

--- a/src/components/email-list/EmailList.tsx
+++ b/src/components/email-list/EmailList.tsx
@@ -27,6 +27,7 @@ export interface EmailListState {
 class _EmailList extends React.Component<EmailListProps, EmailListState> {
   stateOptions: Array<ReactSelectOption>;
   selectStyles = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     option: (provided: any) => ({
       ...provided,
       color: "black",


### PR DESCRIPTION
I think due to React Select selectStyles requiring an any type, it always triggers a no-explicit-any warning, so this will simply suppress that warning, since it always shows up and I don't know if it avoidable.