### PR TITLE
Social Previews Update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ badMailtoMessage: Email link not working correctly? You can copy and paste the r
 url: https://defund12.org
 logoUrl: "/images/defund12.org.png"
 faviconUrl: "/favicon.svg"
-metaPreviewUrl: https://defund12-image-api.now.sh/api/preview?
+metaPreviewUrl: https://defund12-image-api.now.sh/api/preview/
 sass:
   sass_dir: _sass
   style: compressed

--- a/_config.yml
+++ b/_config.yml
@@ -29,8 +29,11 @@ siteTitle: Defund12.org
 permalink: pretty
 subtitle: Email and mail government officials and council members to reallocate egregious
   police budgets towards education, social services, and dismantling racial injustice.
-meta: Email government officials and council members to reallocate police budgets
-  towards education, social services, and dismantling racial injustice.
+meta: Send pre-written emails and letters to government officials and council members 
+  to reallocate police budgets towards education, social services, and dismantling racial injustice.
+letterMeta: Send pre-written letters to government officials and council members 
+  to reallocate police budgets towards education, social services, and dismantling racial injustice.
+letterMetaPreviewSubtitle: "Order physical letters to be printed and mailed to government officials and council members."
 footerTextPr: Want to add your city? [Open a request.](https://github.com/defund12/defund12.org/issues)
 footerTextInstructions: Have the emails of your city government officials and a drafted
   template ready.
@@ -42,7 +45,7 @@ badMailtoMessage: Email link not working correctly? You can copy and paste the r
 url: https://defund12.org
 logoUrl: "/images/defund12.org.png"
 faviconUrl: "/favicon.svg"
-metaPreviewUrl: https://defund12-image-api.now.sh/api/preview/
+metaPreviewUrl: https://defund12.rpal.vercel.app/api/preview?
 sass:
   sass_dir: _sass
   style: compressed

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -102,7 +102,10 @@ export default function Layout(
           meta={props.meta ? props.meta : data.siteConfig.meta}
           logoUrl={
             props.metaQueryString
-              ? data.siteConfig.metaPreviewUrl + props.metaQueryString
+              ? data.siteConfig.metaPreviewUrl +
+                props.layout +
+                "?" +
+                props.metaQueryString
               : data.siteConfig.logoUrl
           }
         >

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -102,11 +102,8 @@ export default function Layout(
           meta={props.meta ? props.meta : data.siteConfig.meta}
           logoUrl={
             props.metaQueryString
-              ? data.siteConfig.metaPreviewUrl +
-                props.layout +
-                "?" +
-                props.metaQueryString
-              : data.siteConfig.logoUrl
+              ? data.siteConfig.metaPreviewUrl + props.metaQueryString
+              : data.siteConfig.metaPreviewUrl
           }
         >
           {props.children}

--- a/src/components/email/Email.tsx
+++ b/src/components/email/Email.tsx
@@ -41,11 +41,11 @@ export default class Email extends React.Component<
     this.siteConfig = this.props.data.siteConfig;
     this.emailData = this.props.data.markdownRemark.frontmatter;
     this.layoutProps = {
-      pageTitle: `Defund12 in ${this.emailData.city}, ${this.emailData.state}`,
-      meta: `Send a pre-written email directly to ${this.emailData.city}, ${this.emailData.state} officials`,
+      pageTitle: `Defund12.org in ${this.emailData.city}, ${this.emailData.state}`,
+      meta: `Send a pre-written email directly to ${this.emailData.city}, ${this.emailData.state} officials.`,
       metaQueryString: queryString.stringify({
-        state: this.emailData.state,
-        city: this.emailData.city,
+        subheader: `in ${this.emailData.city}, ${this.emailData.state}`,
+        subtitle1: `Send pre-scripted emails to ${this.emailData.city} government officials.`,
       }),
       layout: "email",
     };

--- a/src/components/email/Email.tsx
+++ b/src/components/email/Email.tsx
@@ -47,6 +47,7 @@ export default class Email extends React.Component<
         state: this.emailData.state,
         city: this.emailData.city,
       }),
+      layout: "email",
     };
     this.state = new EmailState();
   }

--- a/src/components/letter/Letter.tsx
+++ b/src/components/letter/Letter.tsx
@@ -1,21 +1,25 @@
 import { graphql, PageProps } from "gatsby";
 import React from "react";
 import { LetterData } from "../../types/TemplateData";
-import { LetterProps, LetterConfig } from "../../types/PropTypes";
+import {
+  LetterConfig,
+  LetterProps,
+  OptionalLayoutProps,
+} from "../../types/PropTypes";
 import Layout from "../common/Layout";
 import LetterList from "../template-list/LetterList";
 import LetterForm from "./LetterForm";
 import { OfficialRestrict } from "../../services/OfficialTypes";
 import { DefundUtils } from "../../DefundUtils";
+import * as queryString from "query-string";
 
 /**
  * A rendered email, containing links to send or copy.
  */
 export default class Letter extends React.Component<PageProps<LetterProps>> {
   letterData: LetterData;
-  title: string;
-  meta: string;
   siteConfig: LetterConfig;
+  layoutProps: OptionalLayoutProps;
 
   /**
    * Initialize the component and its state.
@@ -26,8 +30,15 @@ export default class Letter extends React.Component<PageProps<LetterProps>> {
     console.log(this.props);
     this.siteConfig = this.props.data.siteConfig;
     this.letterData = this.props.data.markdownRemark.frontmatter;
-    this.title = `Defund 12 in ${this.letterData.city}, ${this.letterData.state}`;
-    this.meta = `Send a pre-written letter directly to ${this.letterData.city}, ${this.letterData.state} officials`;
+    this.layoutProps = {
+      pageTitle: `Defund12 in ${this.letterData.city}, ${this.letterData.state}`,
+      meta: `Send a pre-written letter directly to ${this.letterData.city}, ${this.letterData.state} officials`,
+      metaQueryString: queryString.stringify({
+        state: this.letterData.state,
+        city: this.letterData.city,
+      }),
+      layout: "letter",
+    };
   }
 
   /**
@@ -53,7 +64,7 @@ export default class Letter extends React.Component<PageProps<LetterProps>> {
     };
 
     return (
-      <Layout pageTitle={this.title} meta={this.meta}>
+      <Layout {...this.layoutProps}>
         <section className="emailPageHeader">
           <h2>{this.letterData.name}</h2>
           <b>

--- a/src/components/letter/Letter.tsx
+++ b/src/components/letter/Letter.tsx
@@ -31,11 +31,11 @@ export default class Letter extends React.Component<PageProps<LetterProps>> {
     this.siteConfig = this.props.data.siteConfig;
     this.letterData = this.props.data.markdownRemark.frontmatter;
     this.layoutProps = {
-      pageTitle: `Defund12 in ${this.letterData.city}, ${this.letterData.state}`,
-      meta: `Send a pre-written letter directly to ${this.letterData.city}, ${this.letterData.state} officials`,
+      pageTitle: `Defund12.org in ${this.letterData.city}, ${this.letterData.state}`,
+      meta: `Send a pre-written letter directly to ${this.letterData.city}, ${this.letterData.state} officials.`,
       metaQueryString: queryString.stringify({
-        state: this.letterData.state,
-        city: this.letterData.city,
+        subheader: `in ${this.letterData.city}, ${this.letterData.state}`,
+        subtitle1: `Order physical letters to be printed and mailed to ${this.letterData.city} government officials.`,
       }),
       layout: "letter",
     };

--- a/src/pages/letters.tsx
+++ b/src/pages/letters.tsx
@@ -4,6 +4,7 @@ import Layout from "../components/common/Layout";
 import TemplateList from "../components/template-list/TemplateList";
 import { SiteProps, LettersPageConfig } from "../types/PropTypes";
 import { DefundUtils } from "../DefundUtils";
+import * as queryString from "query-string";
 
 /**
  * Contains a list just like the homepage, but with letters.
@@ -28,6 +29,8 @@ export default class Letters extends React.Component<PageProps<SiteProps>> {
           query LetterPageQuery {
             siteConfig {
               letterPageHeader
+              letterMetaPreviewSubtitle
+              letterMeta
             }
           }
         `}
@@ -42,8 +45,16 @@ export default class Letters extends React.Component<PageProps<SiteProps>> {
             ></span>
           );
 
+          const layoutProps = {
+            pageTitle: "Letters by Defund12.org",
+            meta: data.siteConfig.letterMeta,
+            metaQueryString: queryString.stringify({
+              subtitle1: data.siteConfig.letterMetaPreviewSubtitle,
+            }),
+          };
+
           return (
-            <Layout>
+            <Layout {...layoutProps}>
               <TemplateList layout="letter" header={header} />
             </Layout>
           );

--- a/src/types/PropTypes.ts
+++ b/src/types/PropTypes.ts
@@ -52,6 +52,7 @@ export interface OptionalLayoutProps {
   pageTitle?: string;
   meta?: string;
   metaQueryString?: string;
+  layout?: string;
 }
 
 // {Static query result properties}

--- a/src/types/PropTypes.ts
+++ b/src/types/PropTypes.ts
@@ -39,7 +39,10 @@ export type LetterConfig = Pick<
   | "googleApiKey"
 >;
 
-export type LettersPageConfig = Pick<SiteConfig, "letterPageHeader">;
+export type LettersPageConfig = Pick<
+  SiteConfig,
+  "letterPageHeader" | "letterMetaPreviewSubtitle" | "letterMeta"
+>;
 
 export interface LetterProps {
   markdownRemark: {

--- a/src/types/SiteConfig.ts
+++ b/src/types/SiteConfig.ts
@@ -6,6 +6,8 @@ export interface SiteConfig {
   /** Name that appears as the tab or window title. */
   meta: string;
   /** A URL pointing to the site logo. */
+  letterMeta: string;
+  /** A URL pointing to the site logo. */
   logoUrl: string;
   /** A URL pointing to a favicon logo. */
   faviconUrl: string;
@@ -25,6 +27,8 @@ export interface SiteConfig {
   contactEmailFooter: string;
   /** A message that appears before the physical letter list index page */
   letterPageHeader: string;
+  /** Subtitle string for the image preview generation API */
+  letterMetaPreviewSubtitle: string;
   /** Google API key with Maps and Civic Info perms */
   googleApiKey: string;
 }


### PR DESCRIPTION
changed the way information is passed to the image api
rather than pass city, state, layout, etc. to then be formatted in the string template server side, now the string processing is done on the frontend, which gives direct control over what text is displayed in the image template. this will allow for fluid changes to be made with social previews, rather than having to change the api

note: merge and deploy the image api PR before merging this one