### PR TITLE
add manual address entry to letter form

### DIFF
--- a/src/components/common/DynamicList.tsx
+++ b/src/components/common/DynamicList.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { DynamicListProps } from "./PropTypes";
+import { v1 as uuid } from "uuid";
+import { isFunction } from "lodash";
+
+interface DynamicListState<TModel> {
+  listItems: Array<TModel>;
+  keys: Array<string>;
+}
+
+/**
+ * A component that can generate an arbitrary number
+ * of instances of a component provided by the caller.
+ */
+export default class DynamicList<TModel> extends React.Component<
+  DynamicListProps<TModel>,
+  DynamicListState<TModel>
+> {
+  /**
+   * Initialize component and its state.
+   * @param {DynamicListProps<TModel>} props
+   */
+  constructor(props: DynamicListProps<TModel>) {
+    super(props);
+    this.state = {
+      listItems: [],
+      keys: [],
+    };
+  }
+
+  /**
+   * Removes the child component instance at the provided index.
+   * @param {number} index
+   */
+  deleteItem(index: number): void {
+    const updatedListItems = [...this.state.listItems];
+    updatedListItems.splice(index, 1);
+
+    const updatedKeys = [...this.state.keys];
+    updatedKeys.splice(index, 1);
+
+    this.setState({ listItems: updatedListItems, keys: updatedKeys });
+    this.props.updateModel(this.state.listItems);
+  }
+
+  /**
+   * Creates a new child component instance.
+   */
+  addItem(): void {
+    const updatedListItems = [
+      ...this.state.listItems,
+      this.props.modelFactory(),
+    ];
+    const updatedKeys = [...this.state.keys, uuid()];
+
+    this.setState({ listItems: updatedListItems, keys: updatedKeys });
+    this.props.updateModel(this.state.listItems);
+  }
+
+  /**
+   * Replaces the child component state at the provided
+   * index with the provided value.
+   * @param {number} index the index of the child instance to update
+   * @param {TModel} value the new state value
+   */
+  updateItem(index: number, value: TModel): void {
+    const updatedModel = [...this.state.listItems];
+    updatedModel[index] = value;
+    this.setState({ listItems: updatedModel });
+    this.props.updateModel(this.state.listItems);
+  }
+
+  /**
+   * Renders each child instance using the component provided in the caller.
+   * @return {React.ReactNode} the rendered child components
+   */
+  renderChildren(): React.ReactNode {
+    return this.state.listItems.map((entry: TModel, index: number) => {
+      return (
+        <div key={this.state.keys[index]}>
+          <button onClick={() => this.deleteItem(index)}>Delete</button>
+          {this.props.eachRender((value: TModel) =>
+            this.updateItem(index, value)
+          )}
+        </div>
+      );
+    });
+  }
+
+  /**
+   * React render method.
+   * @return {React.ReactNode} the rendered component
+   */
+  render(): React.ReactNode {
+    return (
+      <>
+        {this.renderChildren()}
+        <button onClick={() => this.addItem()}>
+          {isFunction(this.props.addText)
+            ? this.props.addText(this.state.listItems)
+            : this.props.addText}
+        </button>
+      </>
+    );
+  }
+}

--- a/src/components/common/PropTypes.ts
+++ b/src/components/common/PropTypes.ts
@@ -1,0 +1,6 @@
+export interface DynamicListProps<TModel> {
+  addText: string | ((listItems: Array<TModel>) => string);
+  modelFactory: () => TModel;
+  updateModel: (value: Array<TModel>) => void;
+  eachRender: (updateModel: (value: TModel) => void) => JSX.Element;
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,0 +1,5 @@
+export { default as Footer } from "./Footer";
+export { default as Header } from "./Header";
+export { default as Layout } from "./Layout";
+export { default as DynamicList } from "./DynamicList";
+export * from "./PropTypes";

--- a/src/components/letter/AddressInput.tsx
+++ b/src/components/letter/AddressInput.tsx
@@ -1,0 +1,110 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import React, { useState, ReactElement } from "react";
+
+import { LobAddress } from "./LetterTypes";
+
+type AddressInputProps = {
+  /** callback function for every time the address is updated */
+  updateParent: (a: LobAddress) => void;
+};
+
+/** Renders input fields for the user's address
+ *
+ * @return {ReactElement} the rendered component
+ */
+export default function AddressInput({
+  updateParent,
+}: AddressInputProps): ReactElement {
+  const [address, setAddress] = useState({} as LobAddress);
+
+  /** Callback for when part of user's address is updated.
+   * adds it to the full address in our internal state and
+   * calls the parent's callback
+   *
+   * @param {Address} addressPatch the updated address
+   */
+  function updateAddress(addressPatch: Partial<LobAddress>) {
+    const updatedAddress = { ...address, ...addressPatch };
+    setAddress(updatedAddress);
+    updateParent(updatedAddress);
+  }
+
+  return (
+    <>
+      <fieldset className="pure-form-stacked">
+        <div className="pure-control-group">
+          <label>Name</label>
+          <input
+            className="pure-u-1"
+            placeholder="Name"
+            type="text"
+            name="name"
+            onChange={(e) =>
+              updateAddress({
+                name: e.target.value,
+              })
+            }
+          />
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <div className="pure-control-group">
+          <label>Address</label>
+
+          <input
+            className="pure-u-1"
+            placeholder="123 Main St"
+            type="text"
+            name="address"
+            onChange={(e) =>
+              updateAddress({
+                address_line1: e.target.value,
+              })
+            }
+          />
+
+          <div className="pure-g">
+            <div className="right-pad-input pure-u-1 pure-u-md-1-3">
+              <input
+                placeholder="City"
+                name="city"
+                onChange={(e) =>
+                  updateAddress({
+                    address_city: e.target.value,
+                  })
+                }
+              />
+            </div>
+            <div className="right-pad-input pure-u-1 pure-u-md-1-3">
+              <input
+                placeholder="State"
+                type="text"
+                name="state"
+                onChange={(e) =>
+                  updateAddress({
+                    address_state: e.target.value,
+                  })
+                }
+              />
+            </div>
+
+            <div className="pure-u-1 pure-u-md-1-3">
+              <input
+                className="full-width"
+                placeholder="Zipcode"
+                type="text"
+                name="zip"
+                onChange={(e) =>
+                  updateAddress({
+                    address_zip: e.target.value,
+                  })
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </>
+  );
+}

--- a/src/components/letter/LetterForm.tsx
+++ b/src/components/letter/LetterForm.tsx
@@ -9,11 +9,13 @@ import "purecss/build/grids-responsive-min.css";
 import { Template, LobAddress } from "./LetterTypes";
 import CheckoutForm from "./CheckoutForm";
 import MyAddressInput from "./MyAddressInput";
+import AddressInput from "./AddressInput";
 import { CombinedOfficialFetchingService } from "../../services/CombinedOfficialFetchingService";
 import { OfficialAddressCheckboxList } from "./OfficialAddressCheckboxList";
 import { TemplateInputs } from "./TemplateInputs";
 import { OfficialAddress } from "../../services/OfficialTypes";
 import { lobAddressToSingleLine } from "./LobAddressUtils";
+import { DynamicList } from "../common";
 
 const SpecialVars = ["YOUR NAME"]; // , "YOUR DISTRICT"];
 
@@ -65,6 +67,9 @@ function LetterForm({ template, googleApiKey }: LetterFormProps): ReactElement {
   const [myAddress, setMyAddress] = useState({} as LobAddress);
   const [variableMap, setVariableMap] = useState({} as Record<string, string>);
   const [checkedAddresses, setCheckedAddresses] = useState([] as LobAddress[]);
+  const [additionalAddresses, setAdditionalAddresses] = useState(
+    [] as LobAddress[]
+  );
   const [officials, setOfficials] = useState([] as OfficialAddress[]);
   const [isSearching, setIsSearching] = useState(false);
 
@@ -214,8 +219,21 @@ function LetterForm({ template, googleApiKey }: LetterFormProps): ReactElement {
             />
           )}
 
+          <DynamicList
+            addText={(addresses) =>
+              addresses.length === 0
+                ? "Add Missing Representative"
+                : "Add Another"
+            }
+            updateModel={setAdditionalAddresses}
+            modelFactory={() => ({} as LobAddress)}
+            eachRender={(setEachAddress: (a: LobAddress) => void) => (
+              <AddressInput updateParent={setEachAddress} />
+            )}
+          />
+
           <CheckoutForm
-            checkedAddresses={checkedAddresses}
+            checkedAddresses={[...checkedAddresses, ...additionalAddresses]}
             myAddress={myAddress}
             body={bodyText}
             allVariablesFilledIn={allVariablesFilledIn}


### PR DESCRIPTION
This PR adds an arbitrary-length list component, used in the letter form to allow users to input addresses that are not populated automatically from the Civic API.